### PR TITLE
docs(mcp): add Goody MCP server section (guide + reference + capabilities)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -55,7 +55,8 @@
               "mcp/overview",
               "mcp/connect",
               "mcp/authentication",
-              "mcp/gifting-flow"
+              "mcp/gifting-flow",
+              "mcp/data-handling"
             ]
           },
           {
@@ -218,9 +219,71 @@
             ]
           },
           {
-            "group": "Catalog & discovery",
+            "group": "Account & workspaces",
             "pages": [
-              "mcp-reference/tools/products-search"
+              "mcp-reference/tools/me-get",
+              "mcp-reference/tools/workspaces-list"
+            ]
+          },
+          {
+            "group": "Discover gifts & cards",
+            "pages": [
+              "mcp-reference/tools/products-search",
+              "mcp-reference/tools/products-get",
+              "mcp-reference/tools/collections-list",
+              "mcp-reference/tools/gift-of-choice-list",
+              "mcp-reference/tools/cards-list"
+            ]
+          },
+          {
+            "group": "Contacts",
+            "pages": [
+              "mcp-reference/tools/contacts-search",
+              "mcp-reference/tools/contacts-get",
+              "mcp-reference/tools/contacts-create",
+              "mcp-reference/tools/contacts-update",
+              "mcp-reference/tools/contact-lists-list",
+              "mcp-reference/tools/contact-lists-create"
+            ]
+          },
+          {
+            "group": "Messages",
+            "pages": [
+              "mcp-reference/tools/messages-generate"
+            ]
+          },
+          {
+            "group": "Payment methods",
+            "pages": [
+              "mcp-reference/tools/payment-methods-list"
+            ]
+          },
+          {
+            "group": "Send & track gifts",
+            "pages": [
+              "mcp-reference/tools/order-batches-preview",
+              "mcp-reference/tools/order-batches-price",
+              "mcp-reference/tools/order-batches-create",
+              "mcp-reference/tools/order-batches-list",
+              "mcp-reference/tools/order-batches-get",
+              "mcp-reference/tools/orders-list",
+              "mcp-reference/tools/orders-cancel"
+            ]
+          },
+          {
+            "group": "Autogifts",
+            "pages": [
+              "mcp-reference/tools/autogift-rules-list",
+              "mcp-reference/tools/autogift-rules-create",
+              "mcp-reference/tools/autogift-rules-preview",
+              "mcp-reference/tools/autogift-rules-activate",
+              "mcp-reference/tools/autogift-rules-pause"
+            ]
+          },
+          {
+            "group": "Feedback",
+            "pages": [
+              "mcp-reference/tools/feedback-create"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "theme": "maple",
-  "name": "Goody",
+  "name": "Goody Developers",
   "colors": {
     "primary": "#9159D6",
     "light": "#B584F1",
@@ -50,7 +50,7 @@
             ]
           },
           {
-            "group": "MCP",
+            "group": "MCP server",
             "pages": [
               "mcp/overview",
               "mcp/connect",
@@ -210,7 +210,7 @@
         "icon": "robot",
         "groups": [
           {
-            "group": "Overview",
+            "group": "Reference",
             "pages": [
               "mcp-reference/capabilities",
               "mcp-reference/example-prompts",

--- a/docs.json
+++ b/docs.json
@@ -50,6 +50,15 @@
             ]
           },
           {
+            "group": "MCP",
+            "pages": [
+              "mcp/overview",
+              "mcp/connect",
+              "mcp/authentication",
+              "mcp/gifting-flow"
+            ]
+          },
+          {
             "group": "Webhooks",
             "pages": [
               "webhooks/overview",
@@ -192,6 +201,26 @@
                   "api-reference/schemas/recipientinput"
                 ]
               }
+            ]
+          }
+        ]
+      },
+      {
+        "anchor": "MCP Reference",
+        "icon": "robot",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "mcp-reference/capabilities",
+              "mcp-reference/example-prompts",
+              "mcp-reference/tools"
+            ]
+          },
+          {
+            "group": "Catalog & discovery",
+            "pages": [
+              "mcp-reference/tools/products-search"
             ]
           }
         ]

--- a/introduction/overview.mdx
+++ b/introduction/overview.mdx
@@ -51,7 +51,7 @@ Send and manage gifts directly from Claude and other AI assistants. Discover a g
 Goody's API has two environments:
 
 - **Production**: https://api.ongoody.com
-- **Sandbox**: https://sandbox.api.ongoody.com
+- **Sandbox**: https://api.sandbox.ongoody.com
 
 ## Start using the API
 

--- a/introduction/overview.mdx
+++ b/introduction/overview.mdx
@@ -1,35 +1,49 @@
 ---
-title: "Goody API"
+title: "Goody for developers"
 sidebarTitle: "Overview"
-description: "Goody's API lets you send physical products and gifts programmatically."
+description: "Send physical products and gifts programmatically with the Goody API, or gift directly from Claude and other AI assistants with the Goody MCP server."
 ---
 
-- **Send gifts without an address**. You can generate a gift link where they can view your gift, have the option of swapping it for something else, and enter their address themselves
-- **Ship physical products to an address**. If you already have an address, Goody can ship products and handle all the logistics.
+Goody lets you send gifts and physical products programmatically — no mailing address required.
 
-## Available APIs
+- **Send gifts without an address**. Generate a gift link where the recipient can view the gift, swap it for something else, and enter their own address.
+- **Ship physical products to an address**. If you already have an address, Goody ships the product and handles all the logistics.
 
-Goody provides two APIs depending on your use case:
+There are two ways to build on Goody:
 
-<Card
-    title="Commerce API — to add commerce to your app"
+## The API
+
+Programmatic gifting and commerce over a REST API.
+
+<CardGroup cols={2}>
+  <Card
+    title="Commerce API"
     icon="truck-ramp-couch"
     href="/commerce-api/overview"
     icontype="duotone"
->
-    Sell physical products in your app without handling inventory, partnerships,
-    or logistics. Access our product catalog, gift without an address, and earn a
-    revenue share.
-</Card>
+  >
+    Sell physical products in your app without handling inventory, partnerships, or logistics. Access our catalog, gift without an address, and earn a revenue share.
+  </Card>
+  <Card
+    title="Automation API"
+    icon="wand-sparkles"
+    href="/automation-api/overview"
+    icontype="duotone"
+  >
+    Automate your own gifting and sending. Create custom integrations to send one or hundreds of gifts programmatically — or use our Zapier app for no-code workflows.
+  </Card>
+</CardGroup>
+
+## The MCP server
+
+Send and manage gifts directly from Claude and other AI assistants. Discover a gift, write the card, confirm the price, and send — all in one conversation, with spending always gated behind your confirmation.
+
 <Card
-  title="Automation API — for Goody customers"
-  icon="wand-sparkles"
-  href="/automation-api/overview"
-  icontype="duotone"
+  title="Goody MCP server"
+  icon="robot"
+  href="/mcp/overview"
 >
-  Automate your own gifting and sending. Create custom integrations to send one
-  or hundreds of gifts programmatically. Or use our Zapier app for no-code
-  workflows.
+  Connect Goody to Claude in a couple of clicks and gift in natural language. See the MCP Reference for connection, permissions, and the full tool surface.
 </Card>
 
 ## Production and sandbox environments

--- a/mcp-reference/capabilities.mdx
+++ b/mcp-reference/capabilities.mdx
@@ -78,4 +78,4 @@ A quick reference for the questions that come up most. "Not yet" means it's on t
 - Richer, recipient-aware gift suggestions.
 - Meeting-request (Calendly-style) settings on gifts.
 - Applying account credit to gifts sent through the Goody MCP server.
-- One-click connect via the Claude Connectors Directory.
+- One-click connect via the Claude Connectors Directory — rolling out; for now, add Goody as a [custom connector](/mcp/connect).

--- a/mcp-reference/capabilities.mdx
+++ b/mcp-reference/capabilities.mdx
@@ -12,7 +12,7 @@ A candid map of the Goody MCP server's surface — what works today, the current
   <Accordion title="Discover gifts & cards" icon="gift">
     - Search the catalog by intent, budget, and occasion — up to 5 curated matches per search.
     - Retrieve full detail for a single product (description, shipping, alcohol status, US state restrictions).
-    - Browse curated **collections**.
+    - Browse curated **collections** and send one (each published collection carries a `product_id` you send like any product).
     - Offer a **Gift of Choice** the recipient picks themselves, optionally framed to a budget.
     - List Goody greeting cards and filter them by occasion.
     - Draft card-message options for an occasion.
@@ -57,8 +57,8 @@ A quick reference for the questions that come up most. "Not yet" means it's on t
 | **Schedule a gift for a future date** | ✅ Yes | Up to 3 months out. |
 | Gift of Choice (recipient picks) | ✅ Yes | Optionally budget-framed. |
 | Send a **gift card** | ✅ Yes | Gift-card products live in the catalog — search for them like any product. (Distinct from greeting cards.) |
-| Browse **collections** | ✅ Yes | List curated collections (read-only). To send a recipient-picks gift, use a Gift of Choice — a collection can't be sent by its id. |
-| **Create** a gift collection | ⏳ Not via MCP | Build collections in Goody for Business; the MCP server lists them but doesn't create them. |
+| Browse **& send collections** | ✅ Yes | List curated collections and send one via its `product_id` — the recipient picks from it, like a Gift of Choice. |
+| **Create** a gift collection | ⏳ Not via MCP | Build collections in Goody for Business; the MCP server lists and sends them, but doesn't create them. |
 | **Autogifts** (recurring) | ✅ Yes | Birthday / work anniversary / onboarding; clone a past send or build from scratch; created paused. |
 | **Global shipping** | ✅ Yes | US is the default — say the recipient is international and it enables global delivery. |
 | **Pay from Goody Balance or Corporate Account** | ✅ Yes | Alongside saved cards. (Balance-paid gifts require an expiration date.) |

--- a/mcp-reference/capabilities.mdx
+++ b/mcp-reference/capabilities.mdx
@@ -57,7 +57,8 @@ A quick reference for the questions that come up most. "Not yet" means it's on t
 | **Schedule a gift for a future date** | ✅ Yes | Up to 3 months out. |
 | Gift of Choice (recipient picks) | ✅ Yes | Optionally budget-framed. |
 | Send a **gift card** | ✅ Yes | Gift-card products live in the catalog — search for them like any product. (Distinct from greeting cards.) |
-| Browse **collections** | ✅ Yes | List curated collections; Gift of Choice draws from them. |
+| Browse **collections** | ✅ Yes | List curated collections (read-only). To send a recipient-picks gift, use a Gift of Choice — a collection can't be sent by its id. |
+| **Create** a gift collection | ⏳ Not via MCP | Build collections in Goody for Business; the MCP server lists them but doesn't create them. |
 | **Autogifts** (recurring) | ✅ Yes | Birthday / work anniversary / onboarding; clone a past send or build from scratch; created paused. |
 | **Global shipping** | ✅ Yes | US is the default — say the recipient is international and it enables global delivery. |
 | **Pay from Goody Balance or Corporate Account** | ✅ Yes | Alongside saved cards. (Balance-paid gifts require an expiration date.) |

--- a/mcp-reference/capabilities.mdx
+++ b/mcp-reference/capabilities.mdx
@@ -11,32 +11,37 @@ A candid map of the Goody MCP server's surface — what works today, the current
 <AccordionGroup>
   <Accordion title="Discover gifts & cards" icon="gift">
     - Search the catalog by intent, budget, and occasion — up to 5 curated matches per search.
-    - Retrieve full detail for a single product.
+    - Retrieve full detail for a single product (description, shipping, alcohol status, US state restrictions).
     - Browse curated **collections**.
     - Offer a **Gift of Choice** the recipient picks themselves, optionally framed to a budget.
     - List Goody greeting cards and filter them by occasion.
     - Draft card-message options for an occasion.
   </Accordion>
-  <Accordion title="Send & track gifts" icon="paper-plane">
+  <Accordion title="Preview, send & track gifts" icon="paper-plane">
+    - **Preview a gift before sending** — get a shareable link to the assembled gift (card, message, products) plus the full price, without charging or sending.
     - Price a gift in full (subtotal, shipping, estimated tax) — free and repeatable.
-    - Send a gift by **gift link** or **email**, with a greeting card and message, after explicit price confirmation.
+    - Send a gift three ways: a **gift link** you share yourself, an **email** with the gift link, or **direct shipping** to a mailing address — after explicit price confirmation.
+    - **Schedule a send** for a future date (up to 3 months out).
     - Send to a saved contact or an ad-hoc recipient (name + email).
     - **International delivery** when the recipient is abroad (US is the default).
     - Send **gift cards** and other catalog products; recipients can swap their gift unless you disable it.
-    - Review past gift batches and individual orders.
+    - Pay with a saved card, your **Goody Balance**, or a **Corporate Account**.
+    - Review past gift batches and individual orders, and **cancel** an order the recipient hasn't accepted yet.
   </Accordion>
   <Accordion title="Manage contacts" icon="address-book">
     - Search, retrieve, create, and update workspace contacts.
     - Create and list contact lists for group sends and automations.
   </Accordion>
   <Accordion title="Automate recurring gifts" icon="repeat">
-    - Create a recurring **autogift** from a gift you've already sent.
+    - Create a recurring **autogift** two ways: clone a gift you've already sent, or build one from scratch (cart + card + message + payment).
     - Triggers: birthday, work anniversary, and employee onboarding.
+    - **Preview** a rule's gift and per-send cost before activating it.
     - List, activate, and pause autogift rules. Rules are always created paused.
   </Accordion>
   <Accordion title="Account & workspaces" icon="user">
     - Identify the connected account and the server's current time.
     - List the workspaces you can gift from and your saved payment methods (display names only — never card numbers).
+    - Send feedback about Goody straight to the Goody team.
   </Accordion>
 </AccordionGroup>
 
@@ -47,19 +52,22 @@ A quick reference for the questions that come up most. "Not yet" means it's on t
 | Question | Today | Notes |
 |---|---|---|
 | Send a gift without an address | ✅ Yes | Gift link or email; the recipient enters their own address. |
+| **Ship directly to a known address** | ✅ Yes | `direct_send` ships the physical product to a mailing address you provide. US addresses today. |
+| **Preview the exact gift before sending** | ✅ Yes | Returns a shareable link to the assembled, not-yet-sent gift plus its full price — nothing is charged. |
+| **Schedule a gift for a future date** | ✅ Yes | Up to 3 months out. |
 | Gift of Choice (recipient picks) | ✅ Yes | Optionally budget-framed. |
 | Send a **gift card** | ✅ Yes | Gift-card products live in the catalog — search for them like any product. (Distinct from greeting cards.) |
 | Browse **collections** | ✅ Yes | List curated collections; Gift of Choice draws from them. |
-| **Autogifts** (recurring) | ✅ Yes | Birthday / work anniversary / onboarding; cloned from a past send; created paused. |
+| **Autogifts** (recurring) | ✅ Yes | Birthday / work anniversary / onboarding; clone a past send or build from scratch; created paused. |
 | **Global shipping** | ✅ Yes | US is the default — say the recipient is international and it enables global delivery. |
+| **Pay from Goody Balance or Corporate Account** | ✅ Yes | Alongside saved cards. (Balance-paid gifts require an expiration date.) |
+| **Cancel a sent gift** | ✅ Yes | Per order, while the recipient hasn't accepted it yet — releases the hold and refunds any applied credit. |
 | Manage contacts & lists | ✅ Yes | Search, create, update; build lists. |
-| Ship directly to a known address | ⏳ Not yet | Sends go out as a link/email today. |
+| Apply **promo / referral / signup credit** | ⏳ Not yet | Automatic account credit isn't applied to gifts sent through the Goody MCP server yet. (Paying from your Goody **Balance** or **Corporate Account** is supported — see above.) |
 | **Calendly** / meeting-request gifts | ⏳ Not yet | Can't attach a meeting requirement to a gift through the Goody MCP server yet. |
 | Custom / **branded** cards | ⏳ Not yet | Only Goody's standard greeting cards are listed today. |
-| Apply **account credit** (signup/referral/promo) | ⏳ Not yet | Credit isn't applied to gifts sent through the Goody MCP server yet. |
-| Visual card preview inside the chat | ⏳ Not yet | A preview link is returned after sending; no inline card image yet. |
-| Pre-send preview of the exact gift | ⏳ Not yet | The price is shown before sending; a shareable pre-send preview isn't available yet. |
-| **Smart Links** (reusable, multi-claim links) | ⏳ Not yet | Sends target specific recipients (link or email); reusable claim links aren't exposed. |
+| Visual card preview inside the chat | ⏳ Not yet | Greeting cards are presented as named, clickable links today; an inline card picker is coming. |
+| **Smart Links** (reusable, multi-claim links) | ⏳ Not via MCP | Smart Links are a Goody feature — they're just not exposed as an MCP tool yet. Sends here target specific recipients (link, email, or direct ship). |
 | **Swag** / branded merch on demand | ❌ No | Not available through the Goody MCP server. |
 | Send from **Gmail** | ❌ No | Goody's Gmail integration is a separate product; the Goody MCP server is independent of it. |
 | Gift from **another user's** Goody account | ❌ No | The Goody MCP server acts only as the signed-in user, within workspaces they belong to. |
@@ -71,11 +79,10 @@ A quick reference for the questions that come up most. "Not yet" means it's on t
   we're actively exploring. They may change.
 </Note>
 
-- Visual card preview and selection inside the conversation.
+- A visual card preview and picker inside the conversation.
 - Smarter card discovery, so natural occasion language ("onboarding", "new parent") finds the right card.
 - Access to your workspace's custom and branded cards.
-- A shareable preview of the exact gift before you confirm and send.
 - Richer, recipient-aware gift suggestions.
 - Meeting-request (Calendly-style) settings on gifts.
-- Applying account credit to gifts sent through the Goody MCP server.
+- Applying account credit (promo / referral / signup) to gifts sent through the Goody MCP server.
 - One-click connect via the Claude Connectors Directory — rolling out; for now, add Goody as a [custom connector](/mcp/connect).

--- a/mcp-reference/capabilities.mdx
+++ b/mcp-reference/capabilities.mdx
@@ -1,0 +1,81 @@
+---
+title: "Capabilities & roadmap"
+sidebarTitle: "Capabilities & roadmap"
+description: "What the Goody MCP server can do today, what it can't do yet, and what's on the roadmap."
+---
+
+A candid map of the connector's surface — what works today, the current limits, and where it's headed. For the exact tools, see the [tool reference](/mcp-reference/tools).
+
+## What you can do today
+
+<AccordionGroup>
+  <Accordion title="Discover gifts & cards" icon="gift">
+    - Search the catalog by intent, budget, and occasion — up to 5 curated matches per search.
+    - Retrieve full detail for a single product.
+    - Browse curated **collections**.
+    - Offer a **Gift of Choice** the recipient picks themselves, optionally framed to a budget.
+    - List Goody greeting cards and filter them by occasion.
+    - Draft card-message options for an occasion.
+  </Accordion>
+  <Accordion title="Send & track gifts" icon="paper-plane">
+    - Price a gift in full (subtotal, shipping, estimated tax) — free and repeatable.
+    - Send a gift by **gift link** or **email**, with a greeting card and message, after explicit price confirmation.
+    - Send to a saved contact or an ad-hoc recipient (name + email).
+    - **International delivery** when the recipient is abroad (US is the default).
+    - Send **gift cards** and other catalog products; recipients can swap their gift unless you disable it.
+    - Review past gift batches and individual orders.
+  </Accordion>
+  <Accordion title="Manage contacts" icon="address-book">
+    - Search, retrieve, create, and update workspace contacts.
+    - Create and list contact lists for group sends and automations.
+  </Accordion>
+  <Accordion title="Automate recurring gifts" icon="repeat">
+    - Create a recurring **autogift** from a gift you've already sent.
+    - Triggers: birthday, work anniversary, and employee onboarding.
+    - List, activate, and pause autogift rules. Rules are always created paused.
+  </Accordion>
+  <Accordion title="Account & workspaces" icon="user">
+    - Identify the connected account and the server's current time.
+    - List the workspaces you can gift from and your saved payment methods (display names only — never card numbers).
+  </Accordion>
+</AccordionGroup>
+
+## Can it do…?
+
+A quick reference for the questions that come up most. "Not yet" means it's on the roadmap; "No" means it's out of scope for the connector.
+
+| Question | Today | Notes |
+|---|---|---|
+| Send a gift without an address | ✅ Yes | Gift link or email; the recipient enters their own address. |
+| Gift of Choice (recipient picks) | ✅ Yes | Optionally budget-framed. |
+| Send a **gift card** | ✅ Yes | Gift-card products live in the catalog — search for them like any product. (Distinct from greeting cards.) |
+| Browse **collections** | ✅ Yes | List curated collections; Gift of Choice draws from them. |
+| **Autogifts** (recurring) | ✅ Yes | Birthday / work anniversary / onboarding; cloned from a past send; created paused. |
+| **Global shipping** | ✅ Yes | US is the default — say the recipient is international and it enables global delivery. |
+| Manage contacts & lists | ✅ Yes | Search, create, update; build lists. |
+| Ship directly to a known address | ⏳ Not yet | Sends go out as a link/email today. |
+| **Calendly** / meeting-request gifts | ⏳ Not yet | Can't attach a meeting requirement to a gift through the connector yet. |
+| Custom / **branded** cards | ⏳ Not yet | Only Goody's standard greeting cards are listed today. |
+| Apply **account credit** (signup/referral/promo) | ⏳ Not yet | Credit isn't applied to gifts sent through the connector yet. |
+| Visual card preview inside the chat | ⏳ Not yet | A preview link is returned after sending; no inline card image yet. |
+| Pre-send preview of the exact gift | ⏳ Not yet | The price is shown before sending; a shareable pre-send preview isn't available yet. |
+| **Smart Links** (reusable, multi-claim links) | ⏳ Not yet | Sends target specific recipients (link or email); reusable claim links aren't exposed. |
+| **Swag** / branded merch on demand | ❌ No | Not available through the connector. |
+| Send from **Gmail** | ❌ No | Goody's Gmail integration is a separate product; this connector is independent of it. |
+| Gift from **another user's** Goody account | ❌ No | The connector acts only as the signed-in user, within workspaces they belong to. |
+
+## Coming soon
+
+<Note>
+  Roadmap items are directional — not commitments or timelines — and reflect what
+  we're actively exploring. They may change.
+</Note>
+
+- Visual card preview and selection inside the conversation.
+- Smarter card discovery, so natural occasion language ("onboarding", "new parent") finds the right card.
+- Access to your workspace's custom and branded cards.
+- A shareable preview of the exact gift before you confirm and send.
+- Richer, recipient-aware gift suggestions.
+- Meeting-request (Calendly-style) settings on gifts.
+- Applying account credit to gifts sent through the connector.
+- One-click connect via the Claude Connectors Directory.

--- a/mcp-reference/capabilities.mdx
+++ b/mcp-reference/capabilities.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Capabilities & roadmap"
 description: "What the Goody MCP server can do today, what it can't do yet, and what's on the roadmap."
 ---
 
-A candid map of the connector's surface — what works today, the current limits, and where it's headed. For the exact tools, see the [tool reference](/mcp-reference/tools).
+A candid map of the Goody MCP server's surface — what works today, the current limits, and where it's headed. For the exact tools, see the [tool reference](/mcp-reference/tools).
 
 ## What you can do today
 
@@ -42,7 +42,7 @@ A candid map of the connector's surface — what works today, the current limits
 
 ## Can it do…?
 
-A quick reference for the questions that come up most. "Not yet" means it's on the roadmap; "No" means it's out of scope for the connector.
+A quick reference for the questions that come up most. "Not yet" means it's on the roadmap; "No" means it's out of scope for the Goody MCP server.
 
 | Question | Today | Notes |
 |---|---|---|
@@ -54,15 +54,15 @@ A quick reference for the questions that come up most. "Not yet" means it's on t
 | **Global shipping** | ✅ Yes | US is the default — say the recipient is international and it enables global delivery. |
 | Manage contacts & lists | ✅ Yes | Search, create, update; build lists. |
 | Ship directly to a known address | ⏳ Not yet | Sends go out as a link/email today. |
-| **Calendly** / meeting-request gifts | ⏳ Not yet | Can't attach a meeting requirement to a gift through the connector yet. |
+| **Calendly** / meeting-request gifts | ⏳ Not yet | Can't attach a meeting requirement to a gift through the Goody MCP server yet. |
 | Custom / **branded** cards | ⏳ Not yet | Only Goody's standard greeting cards are listed today. |
-| Apply **account credit** (signup/referral/promo) | ⏳ Not yet | Credit isn't applied to gifts sent through the connector yet. |
+| Apply **account credit** (signup/referral/promo) | ⏳ Not yet | Credit isn't applied to gifts sent through the Goody MCP server yet. |
 | Visual card preview inside the chat | ⏳ Not yet | A preview link is returned after sending; no inline card image yet. |
 | Pre-send preview of the exact gift | ⏳ Not yet | The price is shown before sending; a shareable pre-send preview isn't available yet. |
 | **Smart Links** (reusable, multi-claim links) | ⏳ Not yet | Sends target specific recipients (link or email); reusable claim links aren't exposed. |
-| **Swag** / branded merch on demand | ❌ No | Not available through the connector. |
-| Send from **Gmail** | ❌ No | Goody's Gmail integration is a separate product; this connector is independent of it. |
-| Gift from **another user's** Goody account | ❌ No | The connector acts only as the signed-in user, within workspaces they belong to. |
+| **Swag** / branded merch on demand | ❌ No | Not available through the Goody MCP server. |
+| Send from **Gmail** | ❌ No | Goody's Gmail integration is a separate product; the Goody MCP server is independent of it. |
+| Gift from **another user's** Goody account | ❌ No | The Goody MCP server acts only as the signed-in user, within workspaces they belong to. |
 
 ## Coming soon
 
@@ -77,5 +77,5 @@ A quick reference for the questions that come up most. "Not yet" means it's on t
 - A shareable preview of the exact gift before you confirm and send.
 - Richer, recipient-aware gift suggestions.
 - Meeting-request (Calendly-style) settings on gifts.
-- Applying account credit to gifts sent through the connector.
+- Applying account credit to gifts sent through the Goody MCP server.
 - One-click connect via the Claude Connectors Directory.

--- a/mcp-reference/capabilities.mdx
+++ b/mcp-reference/capabilities.mdx
@@ -62,6 +62,8 @@ A quick reference for the questions that come up most. "Not yet" means it's on t
 | **Global shipping** | ✅ Yes | US is the default — say the recipient is international and it enables global delivery. |
 | **Pay from Goody Balance or Corporate Account** | ✅ Yes | Alongside saved cards. (Balance-paid gifts require an expiration date.) |
 | **Cancel a sent gift** | ✅ Yes | Per order, while the recipient hasn't accepted it yet — releases the hold and refunds any applied credit. |
+| **Use from a script, Zapier, or cron job** | ✅ Yes | Mint a personal MCP token (no browser OAuth needed) and connect headlessly. |
+| **Run fully autonomously** (no human at send) | ✅ Yes | Via a token scoped to Send gifts; bounded by your daily spend limit. See [the gifting flow](/mcp/gifting-flow#automatic--agentic-sends). |
 | Manage contacts & lists | ✅ Yes | Search, create, update; build lists. |
 | Apply **promo / referral / signup credit** | ⏳ Not yet | Automatic account credit isn't applied to gifts sent through the Goody MCP server yet. (Paying from your Goody **Balance** or **Corporate Account** is supported — see above.) |
 | **Calendly** / meeting-request gifts | ⏳ Not yet | Can't attach a meeting requirement to a gift through the Goody MCP server yet. |

--- a/mcp-reference/example-prompts.mdx
+++ b/mcp-reference/example-prompts.mdx
@@ -10,7 +10,7 @@ These are real flows the Goody MCP server supports today. Responses are illustra
   A few defaults to know: gift searches return up to **5 curated matches** (ask
   for changes to refine), **US shipping** is the default (say so for
   international recipients), **alcohol** is excluded unless you ask for it, and
-  **prices are always shown before sending**.
+  **you always see a preview and price before anything is sent**.
 </Note>
 
 ## Find a gift under a budget
@@ -29,50 +29,63 @@ Here are five great options under $50:
 5. Coffee + Mug Gift Box — Bean Box, $45
 
 There's also a Goody Gift of Choice at your $50 budget — they'd pick their own
-gift and you only pay what you fund. Want me to price one of these?
+gift and you only pay what you fund. Want me to preview one of these?
 ```
 
-## Price, confirm, and send to one recipient
+## Preview, confirm, and send to one recipient
 
 > "Send the Cold Brew Starter Kit to Sarah Chen at sarah@acme.com with a thank-you card. Email it to her."
 
-The assistant assembles the send — greeting card, optional message, payment method — then **prices it and asks you to confirm before sending**:
+The assistant assembles the send — greeting card, optional message, payment method — then **builds a preview link and prices it**, and asks you to confirm before sending:
 
 ```text Example response
-Here's the summary before I send anything:
+Here's a preview of the gift before I send anything:
+
+🔗 Preview: https://ongoody.com/p/preview/2f9c…  (this is what Sarah will see)
 
 - Gift: Cold Brew Starter Kit — $42.00
 - Recipient: Sarah Chen (sarah@acme.com) — she'll get an email with her gift link
 - Card: "Thank You" with the message we drafted
+- From: Alex Rivera
 - Payment: Visa ending 4242
 - Estimated total: $51.83 ($42.00 gift + $6.00 shipping + $3.83 estimated tax)
 
 Shall I send it?
 ```
 
-After you say yes, it confirms the send and returns a preview link of exactly what the recipient will see. Sarah enters her own shipping details when she accepts — and can swap the gift unless you disable swapping.
+After you say yes, it sends and confirms whether the recipient was notified. Sarah enters her own shipping details when she accepts — and can swap the gift unless you disable swapping.
+
+<Tip>
+  Prefer to ship straight to an address? Say "ship it directly to 123 Main St…"
+  and the assistant uses **direct send** — no email or link, the physical gift
+  goes to the address you give. Want to send later? "Schedule it for next
+  Monday" works too (up to 3 months out).
+</Tip>
 
 ## Add contacts and build a list
 
-> "Add three contacts to my workspace: Maya Patel (maya@northwind.com, birthday March 12), James Okafor (james@northwind.com), and Lena Fischer (lena@northwind.com). Then put all three in a list called 'Northwind account team'."
+> "Add these three new hires to my workspace and put them in an 'Onboarding' list: Maya Patel (maya@northwind.com, birthday March 12), James Okafor (james@northwind.com), and Lena Fischer (lena@northwind.com)."
 
 ```text Example response
-Done — I added all three contacts and created the list "Northwind account team"
-with all 3 in it. You can use this list for a group send or a recurring autogift.
+Done — I added all three contacts and created the list "Onboarding" with all 3
+in it. You can use this list for a group send or a recurring autogift.
 ```
 
 If a contact with the same email already exists, the assistant won't silently overwrite it — it tells you and offers to update the existing contact instead.
 
-## Turn a send into a recurring autogift
+## Turn a gift into a recurring autogift
 
-> "Take that gift I just sent to Sarah and turn it into an automatic birthday gift every year."
+> "Set up a birthday autogift for my Clients list, using that gift I just sent to Sarah as the template."
+
+You can clone a past send like this, or build a brand-new rule from scratch ("set up a $50 birthday autogift for my Clients list with the Cold Brew Kit and a birthday card"). Either way the rule is created paused:
 
 ```text Example response
-I've created the autogift rule:
+Here's a preview of the autogift rule before I activate anything:
 
-- Trigger: Sarah Chen's birthday, every year
-- Gift: Cold Brew Starter Kit, with the same Thank You card and message
+- Trigger: each client's birthday, every year
+- Gift: Cold Brew Starter Kit, with a "Happy Birthday" card and message
 - Payment: Visa ending 4242
+- Expected cost per send: ~$51.83
 
 ⏸️ The rule is created paused — autogifts are always created paused so a recurring
 charge is never set up by accident. Want me to activate it now?

--- a/mcp-reference/example-prompts.mdx
+++ b/mcp-reference/example-prompts.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Example prompts"
 sidebarTitle: "Example prompts"
-description: "Real flows the Goody connector supports today, with illustrative responses."
+description: "Real flows the Goody MCP server supports today, with illustrative responses."
 ---
 
-These are real flows the connector supports today. Responses are illustrative — your products, prices, and contacts will differ — but the shape matches how the connector actually behaves.
+These are real flows the Goody MCP server supports today. Responses are illustrative — your products, prices, and contacts will differ — but the shape matches how the Goody MCP server actually behaves.
 
 <Note>
   A few defaults to know: gift searches return up to **5 curated matches** (ask

--- a/mcp-reference/example-prompts.mdx
+++ b/mcp-reference/example-prompts.mdx
@@ -1,0 +1,81 @@
+---
+title: "Example prompts"
+sidebarTitle: "Example prompts"
+description: "Real flows the Goody connector supports today, with illustrative responses."
+---
+
+These are real flows the connector supports today. Responses are illustrative — your products, prices, and contacts will differ — but the shape matches how the connector actually behaves.
+
+<Note>
+  A few defaults to know: gift searches return up to **5 curated matches** (ask
+  for changes to refine), **US shipping** is the default (say so for
+  international recipients), **alcohol** is excluded unless you ask for it, and
+  **prices are always shown before sending**.
+</Note>
+
+## Find a gift under a budget
+
+> "Find a thank-you gift under $50 for a client who loves coffee."
+
+The assistant searches the catalog with your intent and budget, and typically also offers a **Gift of Choice** — Goody's "let them pick" option where the recipient chooses from a curated collection and you fund the amount.
+
+```text Example response
+Here are five great options under $50:
+
+1. Single-Origin Coffee Trio — Driftaway Coffee, $36
+2. Cold Brew Starter Kit — Grady's, $42
+3. Ceramic Pour-Over Set — Yield Design, $48
+4. Espresso Chocolate Collection — Compartés, $34
+5. Coffee + Mug Gift Box — Bean Box, $45
+
+There's also a Goody Gift of Choice at your $50 budget — they'd pick their own
+gift and you only pay what you fund. Want me to price one of these?
+```
+
+## Price, confirm, and send to one recipient
+
+> "Send the Cold Brew Starter Kit to Sarah Chen at sarah@acme.com with a thank-you card. Email it to her."
+
+The assistant assembles the send — greeting card, optional message, payment method — then **prices it and asks you to confirm before sending**:
+
+```text Example response
+Here's the summary before I send anything:
+
+- Gift: Cold Brew Starter Kit — $42.00
+- Recipient: Sarah Chen (sarah@acme.com) — she'll get an email with her gift link
+- Card: "Thank You" with the message we drafted
+- Payment: Visa ending 4242
+- Estimated total: $51.83 ($42.00 gift + $6.00 shipping + $3.83 estimated tax)
+
+Shall I send it?
+```
+
+After you say yes, it confirms the send and returns a preview link of exactly what the recipient will see. Sarah enters her own shipping details when she accepts — and can swap the gift unless you disable swapping.
+
+## Add contacts and build a list
+
+> "Add three contacts to my workspace: Maya Patel (maya@northwind.com, birthday March 12), James Okafor (james@northwind.com), and Lena Fischer (lena@northwind.com). Then put all three in a list called 'Northwind account team'."
+
+```text Example response
+Done — I added all three contacts and created the list "Northwind account team"
+with all 3 in it. You can use this list for a group send or a recurring autogift.
+```
+
+If a contact with the same email already exists, the assistant won't silently overwrite it — it tells you and offers to update the existing contact instead.
+
+## Turn a send into a recurring autogift
+
+> "Take that gift I just sent to Sarah and turn it into an automatic birthday gift every year."
+
+```text Example response
+I've created the autogift rule:
+
+- Trigger: Sarah Chen's birthday, every year
+- Gift: Cold Brew Starter Kit, with the same Thank You card and message
+- Payment: Visa ending 4242
+
+⏸️ The rule is created paused — autogifts are always created paused so a recurring
+charge is never set up by accident. Want me to activate it now?
+```
+
+Only after you explicitly say yes does the assistant activate the rule. You can ask it to list, pause, or re-activate your autogifts any time ("what autogifts do I have running?").

--- a/mcp-reference/tools.mdx
+++ b/mcp-reference/tools.mdx
@@ -1,0 +1,66 @@
+---
+title: "Tool reference"
+sidebarTitle: "Tools"
+description: "The 24 tools the Goody MCP server exposes, grouped by area, with the permission each one requires."
+---
+
+The server exposes 24 tools. Each is named `goody_<resource>_<verb>` and requires one of three permissions — **Read**, **Write**, or **Send gifts** (see [Authentication](/mcp/authentication)).
+
+## Account & workspaces
+
+| Tool | Permission | Description |
+|---|---|---|
+| `goody_me_get` | Read | Get the connected account's profile and the server's current time. |
+| `goody_workspaces_list` | Read | List the workspaces you can gift from. |
+
+## Discover gifts & cards
+
+| Tool | Permission | Description |
+|---|---|---|
+| `goody_products_search` | Read | Search the catalog by intent, budget, and filters (up to 5 matches). |
+| `goody_products_get` | Read | Retrieve full detail for a single product. |
+| `goody_collections_list` | Read | List curated gift collections. |
+| `goody_gift_of_choice_list` | Read | List "let them pick" Gift of Choice options, optionally budget-framed. |
+| `goody_cards_list` | Read | List greeting cards, filterable by occasion. |
+
+## Contacts
+
+| Tool | Permission | Description |
+|---|---|---|
+| `goody_contacts_search` | Read | Search workspace contacts by name or email. |
+| `goody_contacts_get` | Read | Retrieve a single contact. |
+| `goody_contacts_create` | Write | Add a workspace contact. |
+| `goody_contacts_update` | Write | Update an existing contact. |
+| `goody_contact_lists_list` | Read | List contact lists. |
+| `goody_contact_lists_create` | Write | Create a contact list. |
+
+## Messages
+
+| Tool | Permission | Description |
+|---|---|---|
+| `goody_messages_generate` | Read | Draft card-message options for an occasion. |
+
+## Payment methods
+
+| Tool | Permission | Description |
+|---|---|---|
+| `goody_payment_methods_list` | Read | List saved payment methods (display names only — never card numbers). |
+
+## Send & track gifts
+
+| Tool | Permission | Description |
+|---|---|---|
+| `goody_order_batches_price` | Write | Calculate the full price of a gift before sending. |
+| `goody_order_batches_create` | Send gifts | Send a gift. Requires explicit confirmation of the price. |
+| `goody_order_batches_list` | Read | List past gift batches. |
+| `goody_order_batches_get` | Read | Retrieve a single gift batch. |
+| `goody_orders_list` | Read | List individual orders. |
+
+## Autogifts
+
+| Tool | Permission | Description |
+|---|---|---|
+| `goody_autogift_rules_list` | Read | List autogift rules. |
+| `goody_autogift_rules_create` | Send gifts | Create a recurring autogift (always created paused). |
+| `goody_autogift_rules_activate` | Send gifts | Activate a paused autogift rule. |
+| `goody_autogift_rules_pause` | Write | Pause an active autogift rule. |

--- a/mcp-reference/tools.mdx
+++ b/mcp-reference/tools.mdx
@@ -1,66 +1,75 @@
 ---
 title: "Tool reference"
 sidebarTitle: "Tools"
-description: "The 24 tools the Goody MCP server exposes, grouped by area, with the permission each one requires."
+description: "The 28 tools the Goody MCP server exposes, grouped by area, with the permission each one requires."
 ---
 
-The server exposes 24 tools. Each is named `goody_<resource>_<verb>` and requires one of three permissions — **Read**, **Write**, or **Send gifts** (see [Authentication](/mcp/authentication)).
+The server exposes 28 tools. Each is named `goody_<resource>_<verb>` and requires one of three permissions — **Read**, **Write**, or **Send gifts** (see [Authentication](/mcp/authentication)). Select a tool for its parameters, returns, and a worked `prompt → tool call → result` example.
 
 ## Account & workspaces
 
 | Tool | Permission | Description |
 |---|---|---|
-| `goody_me_get` | Read | Get the connected account's profile and the server's current time. |
-| `goody_workspaces_list` | Read | List the workspaces you can gift from. |
+| [`goody_me_get`](/mcp-reference/tools/me-get) | Read | Get the connected account's profile and the server's current time. |
+| [`goody_workspaces_list`](/mcp-reference/tools/workspaces-list) | Read | List the workspaces you can gift from. |
 
 ## Discover gifts & cards
 
 | Tool | Permission | Description |
 |---|---|---|
-| `goody_products_search` | Read | Search the catalog by intent, budget, and filters (up to 5 matches). |
-| `goody_products_get` | Read | Retrieve full detail for a single product. |
-| `goody_collections_list` | Read | List curated gift collections. |
-| `goody_gift_of_choice_list` | Read | List "let them pick" Gift of Choice options, optionally budget-framed. |
-| `goody_cards_list` | Read | List greeting cards, filterable by occasion. |
+| [`goody_products_search`](/mcp-reference/tools/products-search) | Read | Search the catalog by intent, budget, and filters (up to 5 matches). |
+| [`goody_products_get`](/mcp-reference/tools/products-get) | Read | Retrieve full detail for a single product. |
+| [`goody_collections_list`](/mcp-reference/tools/collections-list) | Read | List curated gift collections. |
+| [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list) | Read | List "let them pick" Gift of Choice options, optionally budget-framed. |
+| [`goody_cards_list`](/mcp-reference/tools/cards-list) | Read | List greeting cards, filterable by occasion. |
 
 ## Contacts
 
 | Tool | Permission | Description |
 |---|---|---|
-| `goody_contacts_search` | Read | Search workspace contacts by name or email. |
-| `goody_contacts_get` | Read | Retrieve a single contact. |
-| `goody_contacts_create` | Write | Add a workspace contact. |
-| `goody_contacts_update` | Write | Update an existing contact. |
-| `goody_contact_lists_list` | Read | List contact lists. |
-| `goody_contact_lists_create` | Write | Create a contact list. |
+| [`goody_contacts_search`](/mcp-reference/tools/contacts-search) | Read | Search workspace contacts by name or email. |
+| [`goody_contacts_get`](/mcp-reference/tools/contacts-get) | Read | Retrieve a single contact, with event dates. |
+| [`goody_contacts_create`](/mcp-reference/tools/contacts-create) | Write | Add a workspace contact. |
+| [`goody_contacts_update`](/mcp-reference/tools/contacts-update) | Write | Update an existing contact. |
+| [`goody_contact_lists_list`](/mcp-reference/tools/contact-lists-list) | Read | List contact lists. |
+| [`goody_contact_lists_create`](/mcp-reference/tools/contact-lists-create) | Write | Create a contact list, optionally with members. |
 
 ## Messages
 
 | Tool | Permission | Description |
 |---|---|---|
-| `goody_messages_generate` | Read | Draft card-message options for an occasion. |
+| [`goody_messages_generate`](/mcp-reference/tools/messages-generate) | Read | Draft three card-message options for an occasion. |
 
 ## Payment methods
 
 | Tool | Permission | Description |
 |---|---|---|
-| `goody_payment_methods_list` | Read | List saved payment methods (display names only — never card numbers). |
+| [`goody_payment_methods_list`](/mcp-reference/tools/payment-methods-list) | Read | List saved payment methods, Goody Balance, and Corporate Account (display names only — never card numbers). |
 
 ## Send & track gifts
 
 | Tool | Permission | Description |
 |---|---|---|
-| `goody_order_batches_price` | Write | Calculate the full price of a gift before sending. Needs Write because it builds a draft order to estimate the total — a create-style preview, not a charge (see [Authentication](/mcp/authentication)). |
-| `goody_order_batches_create` | Send gifts | Send a gift. Requires explicit confirmation of the price. |
-| `goody_order_batches_list` | Read | List past gift batches. |
-| `goody_order_batches_get` | Read | Retrieve a single gift batch. |
-| `goody_orders_list` | Read | List individual orders. |
+| [`goody_order_batches_preview`](/mcp-reference/tools/order-batches-preview) | Write | Build a shareable preview link and price a gift that hasn't been sent. The confirmation step. |
+| [`goody_order_batches_price`](/mcp-reference/tools/order-batches-price) | Write | Estimate the full price of a gift. A quick estimate; needs Write because it builds a draft order (see [Authentication](/mcp/authentication)). |
+| [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create) | Send gifts | Send a gift. Requires explicit confirmation of the price. |
+| [`goody_order_batches_list`](/mcp-reference/tools/order-batches-list) | Read | List past gift batches. |
+| [`goody_order_batches_get`](/mcp-reference/tools/order-batches-get) | Read | Retrieve a single gift batch. |
+| [`goody_orders_list`](/mcp-reference/tools/orders-list) | Read | List individual orders, optionally within a batch. |
+| [`goody_orders_cancel`](/mcp-reference/tools/orders-cancel) | Write | Cancel a single order the recipient hasn't accepted yet. |
 
 ## Autogifts
 
 | Tool | Permission | Description |
 |---|---|---|
-| `goody_autogift_rules_list` | Read | List autogift rules. |
-| `goody_autogift_rules_create` | Send gifts | Create a recurring autogift (always created paused). |
-| `goody_autogift_rules_activate` | Send gifts | Activate a paused autogift rule. |
-| `goody_autogift_rules_pause` | Write | Pause an active autogift rule. |
+| [`goody_autogift_rules_list`](/mcp-reference/tools/autogift-rules-list) | Read | List autogift rules. |
+| [`goody_autogift_rules_create`](/mcp-reference/tools/autogift-rules-create) | Send gifts | Create a recurring autogift — clone a past send or build from scratch (always created paused). |
+| [`goody_autogift_rules_preview`](/mcp-reference/tools/autogift-rules-preview) | Read | Preview a paused rule's gift and per-send cost before activating. |
+| [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate) | Send gifts | Activate a paused autogift rule. |
+| [`goody_autogift_rules_pause`](/mcp-reference/tools/autogift-rules-pause) | Write | Pause an active autogift rule. |
+
+## Feedback
+
+| Tool | Permission | Description |
+|---|---|---|
+| [`goody_feedback_create`](/mcp-reference/tools/feedback-create) | Write | Send the user's feedback about Goody to the Goody team. Never charges. |

--- a/mcp-reference/tools.mdx
+++ b/mcp-reference/tools.mdx
@@ -50,7 +50,7 @@ The server exposes 24 tools. Each is named `goody_<resource>_<verb>` and require
 
 | Tool | Permission | Description |
 |---|---|---|
-| `goody_order_batches_price` | Write | Calculate the full price of a gift before sending. |
+| `goody_order_batches_price` | Write | Calculate the full price of a gift before sending. Needs Write because it builds a draft order to estimate the total — a create-style preview, not a charge (see [Authentication](/mcp/authentication)). |
 | `goody_order_batches_create` | Send gifts | Send a gift. Requires explicit confirmation of the price. |
 | `goody_order_batches_list` | Read | List past gift batches. |
 | `goody_order_batches_get` | Read | Retrieve a single gift batch. |

--- a/mcp-reference/tools/autogift-rules-activate.mdx
+++ b/mcp-reference/tools/autogift-rules-activate.mdx
@@ -1,0 +1,85 @@
+---
+title: "goody_autogift_rules_activate"
+sidebarTitle: "autogift_rules_activate"
+description: "Activate a paused autogift rule so it begins scheduling future gifts."
+---
+
+**Permission:** `Send gifts` · **Workspace:** required (from `goody_workspaces_list`)
+
+Activates a paused rule so it begins scheduling future gifts against its contact list.
+
+<Note>
+  Activation commits the recurring spend — preview the rule with [`goody_autogift_rules_preview`](/mcp-reference/tools/autogift-rules-preview) and get the user's confirmation first.
+</Note>
+
+The rule is re-validated before activating and fails cleanly if the product was discontinued, the payment method was removed, or required fields are missing.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. The rule must belong to this workspace.
+</ParamField>
+
+<ParamField body="autogift_rule_id" type="string" required>
+  Rule UUID — from [`goody_autogift_rules_list`](/mcp-reference/tools/autogift-rules-list).
+</ParamField>
+
+## Returns
+
+<ResponseField name="autogift_rule" type="object">
+  The now-active rule.
+  <Expandable title="autogift_rule">
+    <ResponseField name="id" type="string">Rule UUID.</ResponseField>
+    <ResponseField name="status" type="string">Now `active`.</ResponseField>
+    <ResponseField name="event_type" type="string">The occasion that triggers a send.</ResponseField>
+    <ResponseField name="contact_list" type="object">
+      The contact list the rule watches.
+      <Expandable title="contact_list">
+        <ResponseField name="id" type="string">Contact list UUID.</ResponseField>
+        <ResponseField name="name" type="string">The list's visible name.</ResponseField>
+      </Expandable>
+    </ResponseField>
+    <ResponseField name="card_id" type="string | null">The greeting card chosen for the rule.</ResponseField>
+    <ResponseField name="from_name" type="string | null">The "From" name recipients see.</ResponseField>
+    <ResponseField name="message" type="string | null">The gift-card message template.</ResponseField>
+    <ResponseField name="tenure_min" type="integer | null">Lowest years of service the rule applies to.</ResponseField>
+    <ResponseField name="tenure_max" type="integer | null">Highest years of service the rule applies to.</ResponseField>
+    <ResponseField name="created_at" type="string">When the rule was created.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Activate it."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_autogift_rules_activate",
+  "arguments": { "workspace_id": "3f8a…", "autogift_rule_id": "6d2a…" }
+}
+```
+
+```json ↩️ Result
+{
+  "autogift_rule": {
+    "id": "6d2a…",
+    "status": "active",
+    "event_type": "birthday",
+    "contact_list": { "id": "d052…", "name": "Clients" },
+    "card_id": "a7f9…",
+    "from_name": "Jordan at Acme",
+    "message": "Happy birthday, {{firstname}}!",
+    "tenure_min": null,
+    "tenure_max": null,
+    "created_at": "2026-05-02T14:11:00Z"
+  }
+}
+```
+</CodeGroup>
+
+<Tip>
+  Preview before activating with [`goody_autogift_rules_preview`](/mcp-reference/tools/autogift-rules-preview); stop a running rule with [`goody_autogift_rules_pause`](/mcp-reference/tools/autogift-rules-pause).
+</Tip>

--- a/mcp-reference/tools/autogift-rules-create.mdx
+++ b/mcp-reference/tools/autogift-rules-create.mdx
@@ -1,0 +1,175 @@
+---
+title: "goody_autogift_rules_create"
+sidebarTitle: "autogift_rules_create"
+description: "Create a paused autogift rule — clone a past gift or build one from scratch."
+---
+
+**Permission:** `Send gifts` · **Workspace:** required (from `goody_workspaces_list`)
+
+Creates a **paused** autogift rule — a recurring gift that sends automatically when a recipient hits a birthday, work anniversary, or onboarding milestone.
+
+There are two ways to supply the gift contents — pick exactly one:
+
+- **(A) Clone** a recently-sent gift batch with `source_order_batch_id`. The cart, card, message, From name, payment method, and shipping are all pulled from that batch.
+- **(B) Build from scratch** (no prior send) — a cart plus `card_id`, `message`, and `payment_method_id`.
+
+<Note>
+  The rule is created **paused**. Call [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate) once the user confirms — activation is what commits the recurring spend.
+</Note>
+
+## Parameters
+
+### Required
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. The rule is created in this workspace.
+</ParamField>
+
+<ParamField body="event_type" type="string" required>
+  The occasion that triggers a send — one of `birthday`, `work_anniversary`, or `onboarding`.
+</ParamField>
+
+<ParamField body="contact_list_id" type="string">
+  An existing contact list — from [`goody_contact_lists_list`](/mcp-reference/tools/contact-lists-list) or [`goody_contact_lists_create`](/mcp-reference/tools/contact-lists-create). Mutually exclusive with `contact_ids`; supply exactly one.
+</ParamField>
+
+<ParamField body="contact_ids" type="string[]">
+  Contact UUIDs to gift. The tool creates an implicit list from them. Mutually exclusive with `contact_list_id`; supply exactly one.
+</ParamField>
+
+<ParamField body="source_order_batch_id" type="string">
+  The gift batch to clone, from [`goody_order_batches_list`](/mcp-reference/tools/order-batches-list). Mutually exclusive with a from-scratch cart; supply exactly one.
+</ParamField>
+
+### From-scratch path
+
+Supply these instead of `source_order_batch_id` to build the gift without a prior send.
+
+<ParamField body="product_id" type="string">
+  A single product to gift, from [`goody_products_search`](/mcp-reference/tools/products-search). Use this or `cart`.
+  <Expandable title="alongside product_id">
+    <ResponseField name="quantity" type="integer">How many of the product to include.</ResponseField>
+    <ResponseField name="variable_price" type="integer">Funded amount in cents, for a Gift of Choice.</ResponseField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="cart" type="object">
+  Multiple products to gift. Use this or `product_id`.
+  <Expandable title="cart">
+    <ResponseField name="items" type="object[]">Each item names a `product_id` and optional `quantity` / `variable_price`.</ResponseField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="card_id" type="string">
+  Greeting card UUID — from [`goody_cards_list`](/mcp-reference/tools/cards-list).
+</ParamField>
+
+<ParamField body="message" type="string">
+  The gift-card message. Personalization tags (e.g. the recipient's first name) are filled per-recipient at send time.
+</ParamField>
+
+<ParamField body="from_name" type="string">
+  The "From" name recipients see. Defaults to the authenticated user.
+</ParamField>
+
+<ParamField body="payment_method_id" type="string">
+  The autopay payment method the rule charges on activation — from [`goody_payment_methods_list`](/mcp-reference/tools/payment-methods-list). Recommended. Without it the rule is created but won't activate.
+</ParamField>
+
+<ParamField body="international_shipping_tier" type="string">
+  Shipping tier to apply for recipients outside the US.
+</ParamField>
+
+<ParamField body="alcohol_age_verification_attested" type="boolean">
+  Required `true` when the cart contains alcohol.
+</ParamField>
+
+<ParamField body="settings" type="object">
+  Rule settings.
+  <Expandable title="settings">
+    <ResponseField name="gift_cards_enabled" type="boolean">Set `true` to include international gift cards.</ResponseField>
+  </Expandable>
+</ParamField>
+
+### Optional (both paths)
+
+<ParamField body="tenure_min" type="integer">
+  Lowest years of service the rule applies to. Meaningful for `work_anniversary`.
+</ParamField>
+
+<ParamField body="tenure_max" type="integer">
+  Highest years of service the rule applies to. Meaningful for `work_anniversary`.
+</ParamField>
+
+<ParamField body="anchor_date_send_option" type="string">
+  When to send relative to the occasion — `send_on_anchor_date`, `send_before_anchor_date`, or `send_after_anchor_date`.
+</ParamField>
+
+<ParamField body="anchor_date_number_of_days_delta" type="integer">
+  How many days before or after the occasion to send. Required when the send option is before or after.
+</ParamField>
+
+<ParamField body="anchor_date_type" type="string">
+  Which date the occasion anchors to — `start_date` or `added_to_hris_date`. Only for `onboarding`.
+</ParamField>
+
+<ParamField body="allow_occasion_mismatch" type="boolean" default="false">
+  Clone path only. When the source card's occasion doesn't match the event type, the request is rejected; set `true` to override.
+</ParamField>
+
+## Returns
+
+<ResponseField name="autogift_rule" type="object">
+  The newly created, paused rule.
+  <Expandable title="autogift_rule">
+    <ResponseField name="id" type="string">Rule UUID — pass to [`goody_autogift_rules_preview`](/mcp-reference/tools/autogift-rules-preview) or [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate).</ResponseField>
+    <ResponseField name="status" type="string">Always `paused` on creation.</ResponseField>
+    <ResponseField name="event_type" type="string">The occasion that triggers a send.</ResponseField>
+    <ResponseField name="contact_list_id" type="string">The contact list the rule watches.</ResponseField>
+    <ResponseField name="card_id" type="string | null">The greeting card chosen for the rule.</ResponseField>
+    <ResponseField name="message" type="string | null">The gift-card message template.</ResponseField>
+    <ResponseField name="from_name" type="string | null">The "From" name recipients see.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Set up a $50 birthday autogift for my Clients list with the Cold Brew Kit and a birthday card."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_autogift_rules_create",
+  "arguments": {
+    "workspace_id": "3f8a…",
+    "event_type": "birthday",
+    "contact_list_id": "d052…",
+    "product_id": "0f3c…",
+    "card_id": "a7f9…",
+    "message": "Happy birthday, {{firstname}}!",
+    "from_name": "Jordan at Acme",
+    "payment_method_id": "pm_4c19…"
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "autogift_rule": {
+    "id": "6d2a…",
+    "status": "paused",
+    "event_type": "birthday",
+    "contact_list_id": "d052…",
+    "card_id": "a7f9…",
+    "message": "Happy birthday, {{firstname}}!",
+    "from_name": "Jordan at Acme"
+  }
+}
+```
+</CodeGroup>
+
+<Tip>
+  Confirm the gift first with [`goody_autogift_rules_preview`](/mcp-reference/tools/autogift-rules-preview), then turn it on with [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate). To group recipients into a reusable list, use [`goody_contact_lists_create`](/mcp-reference/tools/contact-lists-create).
+</Tip>

--- a/mcp-reference/tools/autogift-rules-list.mdx
+++ b/mcp-reference/tools/autogift-rules-list.mdx
@@ -1,0 +1,100 @@
+---
+title: "goody_autogift_rules_list"
+sidebarTitle: "autogift_rules_list"
+description: "List the autogift (recurring gift) rules in a workspace."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Lists the autogift (recurring gift) rules in a workspace — the rules that send a gift automatically when a recipient hits a birthday, work anniversary, or onboarding milestone.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Rules in this workspace are returned.
+</ParamField>
+
+<ParamField body="status" type="string">
+  Filter by rule state — one of `active`, `paused`, or `inactive`. Omit to return rules in all states.
+</ParamField>
+
+<ParamField body="page" type="integer" default="1">
+  Page number, starting at 1.
+</ParamField>
+
+<ParamField body="per_page" type="integer" default="25">
+  Results per page. Maximum 100.
+</ParamField>
+
+## Returns
+
+<ResponseField name="autogift_rules" type="object[]">
+  The matching autogift rules.
+  <Expandable title="autogift_rule">
+    <ResponseField name="id" type="string">Rule UUID — pass to [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate) or [`goody_autogift_rules_pause`](/mcp-reference/tools/autogift-rules-pause).</ResponseField>
+    <ResponseField name="status" type="string">Rule state — `active`, `paused`, or `inactive`.</ResponseField>
+    <ResponseField name="event_type" type="string">The occasion that triggers a send — e.g. `birthday`, `work_anniversary`, or `onboarding`.</ResponseField>
+    <ResponseField name="contact_list" type="object">
+      The contact list the rule watches.
+      <Expandable title="contact_list">
+        <ResponseField name="id" type="string">Contact list UUID.</ResponseField>
+        <ResponseField name="name" type="string">The list's visible name.</ResponseField>
+      </Expandable>
+    </ResponseField>
+    <ResponseField name="card_id" type="string | null">The greeting card chosen for the rule.</ResponseField>
+    <ResponseField name="from_name" type="string | null">The "From" name recipients see.</ResponseField>
+    <ResponseField name="message" type="string | null">The gift-card message template.</ResponseField>
+    <ResponseField name="tenure_min" type="integer | null">Lowest years of service the rule applies to.</ResponseField>
+    <ResponseField name="tenure_max" type="integer | null">Highest years of service the rule applies to.</ResponseField>
+    <ResponseField name="created_at" type="string">When the rule was created.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="page" type="integer">The current page number.</ResponseField>
+<ResponseField name="per_page" type="integer">Results per page.</ResponseField>
+<ResponseField name="total_count" type="integer">Total number of matching rules across all pages.</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"What autogifts do I have running?"
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_autogift_rules_list",
+  "arguments": { "workspace_id": "3f8a…", "status": "active" }
+}
+```
+
+```json ↩️ Result
+{
+  "autogift_rules": [
+    {
+      "id": "6d2a…",
+      "status": "active",
+      "event_type": "birthday",
+      "contact_list": { "id": "d052…", "name": "Clients" },
+      "card_id": "a7f9…",
+      "from_name": "Jordan at Acme",
+      "message": "Happy birthday, {{firstname}}!",
+      "tenure_min": null,
+      "tenure_max": null,
+      "created_at": "2026-05-02T14:11:00Z"
+    }
+  ],
+  "page": 1,
+  "per_page": 25,
+  "total_count": 1
+}
+```
+</CodeGroup>
+
+<Note>
+  Use a returned `id` with [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate) to turn a rule on, or [`goody_autogift_rules_pause`](/mcp-reference/tools/autogift-rules-pause) to stop further sends.
+</Note>
+
+<Tip>
+  To turn a listed rule on or off, use [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate) and [`goody_autogift_rules_pause`](/mcp-reference/tools/autogift-rules-pause).
+</Tip>

--- a/mcp-reference/tools/autogift-rules-pause.mdx
+++ b/mcp-reference/tools/autogift-rules-pause.mdx
@@ -1,0 +1,79 @@
+---
+title: "goody_autogift_rules_pause"
+sidebarTitle: "autogift_rules_pause"
+description: "Pause an active autogift rule so no further gifts are scheduled."
+---
+
+**Permission:** `Write` · **Workspace:** required (from `goody_workspaces_list`)
+
+Pauses an active rule so no further gifts are scheduled against its contact list. Reversible via [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate).
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. The rule must belong to this workspace.
+</ParamField>
+
+<ParamField body="autogift_rule_id" type="string" required>
+  Rule UUID — from [`goody_autogift_rules_list`](/mcp-reference/tools/autogift-rules-list).
+</ParamField>
+
+## Returns
+
+<ResponseField name="autogift_rule" type="object">
+  The now-paused rule.
+  <Expandable title="autogift_rule">
+    <ResponseField name="id" type="string">Rule UUID.</ResponseField>
+    <ResponseField name="status" type="string">Now `paused`.</ResponseField>
+    <ResponseField name="event_type" type="string">The occasion that triggers a send.</ResponseField>
+    <ResponseField name="contact_list" type="object">
+      The contact list the rule watches.
+      <Expandable title="contact_list">
+        <ResponseField name="id" type="string">Contact list UUID.</ResponseField>
+        <ResponseField name="name" type="string">The list's visible name.</ResponseField>
+      </Expandable>
+    </ResponseField>
+    <ResponseField name="card_id" type="string | null">The greeting card chosen for the rule.</ResponseField>
+    <ResponseField name="from_name" type="string | null">The "From" name recipients see.</ResponseField>
+    <ResponseField name="message" type="string | null">The gift-card message template.</ResponseField>
+    <ResponseField name="tenure_min" type="integer | null">Lowest years of service the rule applies to.</ResponseField>
+    <ResponseField name="tenure_max" type="integer | null">Highest years of service the rule applies to.</ResponseField>
+    <ResponseField name="created_at" type="string">When the rule was created.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Pause my Clients birthday autogift."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_autogift_rules_pause",
+  "arguments": { "workspace_id": "3f8a…", "autogift_rule_id": "6d2a…" }
+}
+```
+
+```json ↩️ Result
+{
+  "autogift_rule": {
+    "id": "6d2a…",
+    "status": "paused",
+    "event_type": "birthday",
+    "contact_list": { "id": "d052…", "name": "Clients" },
+    "card_id": "a7f9…",
+    "from_name": "Jordan at Acme",
+    "message": "Happy birthday, {{firstname}}!",
+    "tenure_min": null,
+    "tenure_max": null,
+    "created_at": "2026-05-02T14:11:00Z"
+  }
+}
+```
+</CodeGroup>
+
+<Tip>
+  Turn the rule back on with [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate), or browse all your rules with [`goody_autogift_rules_list`](/mcp-reference/tools/autogift-rules-list).
+</Tip>

--- a/mcp-reference/tools/autogift-rules-preview.mdx
+++ b/mcp-reference/tools/autogift-rules-preview.mdx
@@ -1,0 +1,98 @@
+---
+title: "goody_autogift_rules_preview"
+sidebarTitle: "autogift_rules_preview"
+description: "Preview what a paused autogift rule will send — card, message, products, and cost — without sending."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Previews what a paused autogift rule will send — the greeting card, message, product(s), and expected per-send cost — without sending, charging, or activating anything. Call it before [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate) and relay the result for confirmation.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. The rule must belong to this workspace.
+</ParamField>
+
+<ParamField body="autogift_rule_id" type="string" required>
+  Rule UUID — from [`goody_autogift_rules_list`](/mcp-reference/tools/autogift-rules-list) or [`goody_autogift_rules_create`](/mcp-reference/tools/autogift-rules-create).
+</ParamField>
+
+## Returns
+
+<ResponseField name="card" type="object | null">
+  The greeting card the rule will send.
+  <Expandable title="card">
+    <ResponseField name="id" type="string">Card UUID.</ResponseField>
+    <ResponseField name="name" type="string">Card name.</ResponseField>
+    <ResponseField name="image_url" type="string">Card image URL.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="message" type="string | null">The gift-card message template.</ResponseField>
+<ResponseField name="from_name" type="string | null">The "From" name recipients see.</ResponseField>
+
+<ResponseField name="products" type="object[]">
+  The product(s) the rule will send.
+  <Expandable title="product">
+    <ResponseField name="product_id" type="string">Product UUID.</ResponseField>
+    <ResponseField name="name" type="string">Product name.</ResponseField>
+    <ResponseField name="quantity" type="integer">How many are included.</ResponseField>
+    <ResponseField name="flex_amount" type="integer | null">Funded amount in cents, for a Gift of Choice.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="expected_spend_per_send" type="object">
+  Estimated cost for a single recipient, in cents.
+  <Expandable title="expected_spend_per_send">
+    <ResponseField name="est_group_total_low" type="integer">Low end of the estimate, in cents.</ResponseField>
+    <ResponseField name="est_group_total_high" type="integer">High end of the estimate, in cents.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"What will my Clients birthday autogift actually send?"
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_autogift_rules_preview",
+  "arguments": { "workspace_id": "3f8a…", "autogift_rule_id": "6d2a…" }
+}
+```
+
+```json ↩️ Result
+{
+  "card": {
+    "id": "a7f9…",
+    "name": "Happy Birthday Confetti",
+    "image_url": "https://ongoody.com/cards/a7f9….png"
+  },
+  "message": "Happy birthday, {{firstname}}!",
+  "from_name": "Jordan at Acme",
+  "products": [
+    {
+      "product_id": "0f3c…",
+      "name": "Cold Brew Starter Kit",
+      "quantity": 1,
+      "flex_amount": null
+    }
+  ],
+  "expected_spend_per_send": {
+    "est_group_total_low": 4200,
+    "est_group_total_high": 5000
+  }
+}
+```
+</CodeGroup>
+
+<Note>
+  The message is shown as its raw template — personalization tags (e.g. the recipient's first name) are filled per-recipient at send time, so no placeholder recipient is invented.
+</Note>
+
+<Tip>
+  Once the preview looks right, turn the rule on with [`goody_autogift_rules_activate`](/mcp-reference/tools/autogift-rules-activate).
+</Tip>

--- a/mcp-reference/tools/cards-list.mdx
+++ b/mcp-reference/tools/cards-list.mdx
@@ -1,0 +1,65 @@
+---
+title: "goody_cards_list"
+sidebarTitle: "cards_list"
+description: "Lists Goody's greeting cards — the card shown with a gift."
+---
+
+**Permission:** `Read` · **Workspace:** not required (global)
+
+Lists Goody's greeting cards — the card shown with a gift (distinct from gift-card products). [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create) requires a `card_id`, so call this before composing a gift. Returns up to **25** cards.
+
+## Parameters
+
+<ParamField body="occasion" type="string">
+  Optional. Filters to cards tagged with a matching occasion name. The match is case-insensitive but **exact** — the full name, not a substring. Common values: `Birthday`, `Congratulations`, `Thank You`, `Work Anniversary`, `Welcome`, `Happy Holidays`, `Get Well`, `Thinking of You`, `Sympathy`, `Just Because`. The vocabulary is data-driven — inspect the `occasions` array on returned cards to find exact tags.
+</ParamField>
+
+## Returns
+
+<ResponseField name="cards" type="object[]">
+  Up to 25 matching cards.
+  <Expandable title="card">
+    <ResponseField name="id" type="string">Card UUID — pass as `card_id` when composing a gift.</ResponseField>
+    <ResponseField name="name" type="string">Card name.</ResponseField>
+    <ResponseField name="image_url" type="string | null">The card artwork.</ResponseField>
+    <ResponseField name="occasions" type="string[]">Occasion tags for this card.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Show me thank-you cards."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_cards_list",
+  "arguments": { "occasion": "Thank You" }
+}
+```
+
+```json ↩️ Result
+{
+  "cards": [
+    {
+      "id": "0f3c…",
+      "name": "Heartfelt Thanks",
+      "image_url": "https://cards.goody.example/heartfelt-thanks.png",
+      "occasions": ["Thank You"]
+    },
+    {
+      "id": "9a17…",
+      "name": "Many Thanks",
+      "image_url": "https://cards.goody.example/many-thanks.png",
+      "occasions": ["Thank You", "Just Because"]
+    }
+  ]
+}
+```
+</CodeGroup>
+
+<Tip>
+  Pass a `card_id` from here to [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create) when composing a gift.
+</Tip>

--- a/mcp-reference/tools/collections-list.mdx
+++ b/mcp-reference/tools/collections-list.mdx
@@ -1,12 +1,16 @@
 ---
 title: "goody_collections_list"
 sidebarTitle: "collections_list"
-description: "Lists a workspace's curated gift collections — pre-built bundles to send instead of a single product."
+description: "Browse a workspace's curated gift collections."
 ---
 
 **Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
 
-Lists the curated gift collections in a workspace — each a pre-built bundle the user can pick instead of a single product. Returns up to **25**.
+Lists the curated gift collections in a workspace — each a pre-built, themed bundle. This is a **browse-and-discover** tool: it helps you and the user see what collections exist. Returns up to **25**.
+
+<Note>
+  Collections are read-only through the MCP server. There's no tool to **create** a collection (build those in Goody for Business), and a collection can't be sent by its `id` — the send tools take a `product_id`, not a collection id. To send a "let the recipient pick from a curated set" gift, use [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list); to send a specific item, find it with [`goody_products_search`](/mcp-reference/tools/products-search).
+</Note>
 
 ## Parameters
 
@@ -15,7 +19,7 @@ Lists the curated gift collections in a workspace — each a pre-built bundle th
 </ParamField>
 
 <ParamField body="published_only" type="boolean" default="false">
-  When true, returns only published collections, skipping drafts. Set true when the user is ready to send.
+  When true, returns only published collections, skipping drafts.
 </ParamField>
 
 ## Returns
@@ -23,7 +27,7 @@ Lists the curated gift collections in a workspace — each a pre-built bundle th
 <ResponseField name="collections" type="object[]">
   Up to 25 collections in the workspace.
   <Expandable title="collection">
-    <ResponseField name="id" type="string">Collection UUID.</ResponseField>
+    <ResponseField name="id" type="string">Collection UUID. Identifies the collection for display; it is not a `product_id` and can't be passed to the send tools.</ResponseField>
     <ResponseField name="workspace_id" type="string">UUID of the owning workspace.</ResponseField>
     <ResponseField name="name" type="string | null">Collection name.</ResponseField>
     <ResponseField name="is_published" type="boolean">True when the collection has a published version.</ResponseField>
@@ -35,13 +39,13 @@ Lists the curated gift collections in a workspace — each a pre-built bundle th
 
 <CodeGroup>
 ```text 💬 Prompt
-"Show me our gift collections."
+"What gift collections do we have?"
 ```
 
 ```json 🔧 Tool call
 {
   "name": "goody_collections_list",
-  "arguments": { "workspace_id": "0f3c…" }
+  "arguments": { "workspace_id": "0f3c…", "published_only": true }
 }
 ```
 
@@ -58,9 +62,9 @@ Lists the curated gift collections in a workspace — each a pre-built bundle th
     {
       "id": "c41a…",
       "workspace_id": "0f3c…",
-      "name": "Holiday Cheer (draft)",
-      "is_published": false,
-      "price_cents": null
+      "name": "Client Appreciation Set",
+      "is_published": true,
+      "price_cents": 12000
     }
   ]
 }
@@ -68,5 +72,5 @@ Lists the curated gift collections in a workspace — each a pre-built bundle th
 </CodeGroup>
 
 <Tip>
-  Discover the workspace first with [`goody_workspaces_list`](/mcp-reference/tools/workspaces-list), or browse individual products with [`goody_products_search`](/mcp-reference/tools/products-search).
+  To send a recipient-picks gift, reach for [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list); for a single product, use [`goody_products_search`](/mcp-reference/tools/products-search).
 </Tip>

--- a/mcp-reference/tools/collections-list.mdx
+++ b/mcp-reference/tools/collections-list.mdx
@@ -1,15 +1,15 @@
 ---
 title: "goody_collections_list"
 sidebarTitle: "collections_list"
-description: "Browse a workspace's curated gift collections."
+description: "List a workspace's curated gift collections — and get the product_id to send one."
 ---
 
 **Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
 
-Lists the curated gift collections in a workspace — each a pre-built, themed bundle. This is a **browse-and-discover** tool: it helps you and the user see what collections exist. Returns up to **25**.
+Lists the curated gift collections in a workspace — each a pre-built, themed gift the recipient picks from. Returns up to **25**. Each published collection includes a **`product_id`** you can send like any other product: the recipient chooses from the collection before accepting, the same way a Gift of Choice works.
 
 <Note>
-  Collections are read-only through the MCP server. There's no tool to **create** a collection (build those in Goody for Business), and a collection can't be sent by its `id` — the send tools take a `product_id`, not a collection id. To send a "let the recipient pick from a curated set" gift, use [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list); to send a specific item, find it with [`goody_products_search`](/mcp-reference/tools/products-search).
+  Collections are **read-only** through the MCP server — there's no tool to **create** one (build collections in Goody for Business). You can, however, **send** a published collection: use its `product_id` (not the collection `id`).
 </Note>
 
 ## Parameters
@@ -19,7 +19,7 @@ Lists the curated gift collections in a workspace — each a pre-built, themed b
 </ParamField>
 
 <ParamField body="published_only" type="boolean" default="false">
-  When true, returns only published collections, skipping drafts.
+  When true, returns only published collections, skipping drafts. Set true when the user is ready to send — only published collections have a `product_id`.
 </ParamField>
 
 ## Returns
@@ -27,11 +27,12 @@ Lists the curated gift collections in a workspace — each a pre-built, themed b
 <ResponseField name="collections" type="object[]">
   Up to 25 collections in the workspace.
   <Expandable title="collection">
-    <ResponseField name="id" type="string">Collection UUID. Identifies the collection for display; it is not a `product_id` and can't be passed to the send tools.</ResponseField>
+    <ResponseField name="id" type="string">Collection UUID. Identifies the collection itself — **not** what you send. To send, use `product_id`.</ResponseField>
     <ResponseField name="workspace_id" type="string">UUID of the owning workspace.</ResponseField>
     <ResponseField name="name" type="string | null">Collection name.</ResponseField>
     <ResponseField name="is_published" type="boolean">True when the collection has a published version.</ResponseField>
     <ResponseField name="price_cents" type="integer | null">Published price in cents; `null` when there's no published version.</ResponseField>
+    <ResponseField name="product_id" type="string | null">The product to **send** this collection through — pass it as `product_id` to [`goody_order_batches_preview`](/mcp-reference/tools/order-batches-preview) / [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create). `null` for unpublished collections (nothing to send yet).</ResponseField>
   </Expandable>
 </ResponseField>
 
@@ -39,7 +40,7 @@ Lists the curated gift collections in a workspace — each a pre-built, themed b
 
 <CodeGroup>
 ```text 💬 Prompt
-"What gift collections do we have?"
+"Send our Welcome Aboard collection to the new hire, jordan@acme.com."
 ```
 
 ```json 🔧 Tool call
@@ -57,20 +58,28 @@ Lists the curated gift collections in a workspace — each a pre-built, themed b
       "workspace_id": "0f3c…",
       "name": "Welcome Aboard Bundle",
       "is_published": true,
-      "price_cents": 8500
-    },
-    {
-      "id": "c41a…",
-      "workspace_id": "0f3c…",
-      "name": "Client Appreciation Set",
-      "is_published": true,
-      "price_cents": 12000
+      "price_cents": 8500,
+      "product_id": "e91d…"
     }
   ]
 }
 ```
 </CodeGroup>
 
+To send it, hand that `product_id` to the normal flow — preview, confirm, send:
+
+```json 🔧 goody_order_batches_preview
+{
+  "name": "goody_order_batches_preview",
+  "arguments": {
+    "workspace_id": "0f3c…",
+    "card_id": "a7f9…",
+    "product_id": "e91d…",
+    "recipients": [{ "name": "Jordan Lee", "email": "jordan@acme.com" }]
+  }
+}
+```
+
 <Tip>
-  To send a recipient-picks gift, reach for [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list); for a single product, use [`goody_products_search`](/mcp-reference/tools/products-search).
+  Need the collection's price type or fundable range before sending? Call [`goody_products_get`](/mcp-reference/tools/products-get) on the `product_id`. For an open-ended "let them pick" gift that isn't a saved collection, use [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list).
 </Tip>

--- a/mcp-reference/tools/collections-list.mdx
+++ b/mcp-reference/tools/collections-list.mdx
@@ -81,5 +81,5 @@ To send it, hand that `product_id` to the normal flow — preview, confirm, send
 ```
 
 <Tip>
-  Need the collection's price type or fundable range before sending? Call [`goody_products_get`](/mcp-reference/tools/products-get) on the `product_id`. For an open-ended "let them pick" gift that isn't a saved collection, use [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list).
+  The collection's price is in `price_cents`; for the full breakdown, run [`goody_order_batches_preview`](/mcp-reference/tools/order-batches-preview) with the `product_id`. (Collection products aren't in the searchable catalog, so [`goody_products_get`](/mcp-reference/tools/products-get) won't find them.) For an open-ended "let them pick" gift that isn't a saved collection, use [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list).
 </Tip>

--- a/mcp-reference/tools/collections-list.mdx
+++ b/mcp-reference/tools/collections-list.mdx
@@ -1,0 +1,72 @@
+---
+title: "goody_collections_list"
+sidebarTitle: "collections_list"
+description: "Lists a workspace's curated gift collections — pre-built bundles to send instead of a single product."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Lists the curated gift collections in a workspace — each a pre-built bundle the user can pick instead of a single product. Returns up to **25**.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID, from [`goody_workspaces_list`](/mcp-reference/tools/workspaces-list).
+</ParamField>
+
+<ParamField body="published_only" type="boolean" default="false">
+  When true, returns only published collections, skipping drafts. Set true when the user is ready to send.
+</ParamField>
+
+## Returns
+
+<ResponseField name="collections" type="object[]">
+  Up to 25 collections in the workspace.
+  <Expandable title="collection">
+    <ResponseField name="id" type="string">Collection UUID.</ResponseField>
+    <ResponseField name="workspace_id" type="string">UUID of the owning workspace.</ResponseField>
+    <ResponseField name="name" type="string | null">Collection name.</ResponseField>
+    <ResponseField name="is_published" type="boolean">True when the collection has a published version.</ResponseField>
+    <ResponseField name="price_cents" type="integer | null">Published price in cents; `null` when there's no published version.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Show me our gift collections."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_collections_list",
+  "arguments": { "workspace_id": "0f3c…" }
+}
+```
+
+```json ↩️ Result
+{
+  "collections": [
+    {
+      "id": "7b22…",
+      "workspace_id": "0f3c…",
+      "name": "Welcome Aboard Bundle",
+      "is_published": true,
+      "price_cents": 8500
+    },
+    {
+      "id": "c41a…",
+      "workspace_id": "0f3c…",
+      "name": "Holiday Cheer (draft)",
+      "is_published": false,
+      "price_cents": null
+    }
+  ]
+}
+```
+</CodeGroup>
+
+<Tip>
+  Discover the workspace first with [`goody_workspaces_list`](/mcp-reference/tools/workspaces-list), or browse individual products with [`goody_products_search`](/mcp-reference/tools/products-search).
+</Tip>

--- a/mcp-reference/tools/contact-lists-create.mdx
+++ b/mcp-reference/tools/contact-lists-create.mdx
@@ -1,0 +1,68 @@
+---
+title: "goody_contact_lists_create"
+sidebarTitle: "contact_lists_create"
+description: "Create a new contact list, optionally with an initial set of members."
+---
+
+**Permission:** `Write` · **Workspace:** required (from `goody_workspaces_list`)
+
+Creates a new active contact list in the workspace, optionally seeded with members. Use the returned id with [`goody_autogift_rules_create`](/mcp-reference/tools/autogift-rules-create).
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. The list is created in this workspace.
+</ParamField>
+
+<ParamField body="name" type="string" required>
+  The visible list name (e.g. "Q3 onboarding cohort").
+</ParamField>
+
+<ParamField body="contact_ids" type="string[]">
+  Optional initial members — contact UUIDs from [`goody_contacts_search`](/mcp-reference/tools/contacts-search) or [`goody_contacts_get`](/mcp-reference/tools/contacts-get). Contacts that aren't in this workspace are silently skipped.
+</ParamField>
+
+## Returns
+
+<ResponseField name="contact_list" type="object">
+  The created list.
+  <Expandable title="contact_list">
+    <ResponseField name="id" type="string">Contact list UUID — pass as `contact_list_id` to [`goody_autogift_rules_create`](/mcp-reference/tools/autogift-rules-create).</ResponseField>
+    <ResponseField name="name" type="string">The visible list name.</ResponseField>
+    <ResponseField name="contact_count" type="integer">Number of contacts added to the list.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Make an 'Onboarding' list with these three contacts."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_contact_lists_create",
+  "arguments": {
+    "workspace_id": "3f8a…",
+    "name": "Onboarding",
+    "contact_ids": ["7b21…", "9c44…", "a1d7…"]
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "contact_list": {
+    "id": "d052…",
+    "name": "Onboarding",
+    "contact_count": 3
+  }
+}
+```
+</CodeGroup>
+
+<Tip>
+  Find members first with [`goody_contacts_search`](/mcp-reference/tools/contacts-search), then point an
+  [`goody_autogift_rules_create`](/mcp-reference/tools/autogift-rules-create) rule at the new list.
+</Tip>

--- a/mcp-reference/tools/contact-lists-list.mdx
+++ b/mcp-reference/tools/contact-lists-list.mdx
@@ -1,0 +1,70 @@
+---
+title: "goody_contact_lists_list"
+sidebarTitle: "contact_lists_list"
+description: "List a workspace's active contact lists, newest first."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Lists the active contact lists in a workspace, newest first. Use it before [`goody_autogift_rules_create`](/mcp-reference/tools/autogift-rules-create) so the user can pick a recipient list.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Lists are scoped to this workspace.
+</ParamField>
+
+<ParamField body="page" type="integer" default="1">
+  Page number, 1-indexed.
+</ParamField>
+
+<ParamField body="per_page" type="integer" default="25">
+  Lists per page. Maximum 100.
+</ParamField>
+
+## Returns
+
+<ResponseField name="contact_lists" type="object[]">
+  The active contact lists, newest first.
+  <Expandable title="contact_list">
+    <ResponseField name="id" type="string">Contact list UUID — pass as `contact_list_id` to [`goody_autogift_rules_create`](/mcp-reference/tools/autogift-rules-create).</ResponseField>
+    <ResponseField name="name" type="string">The visible list name.</ResponseField>
+    <ResponseField name="kind" type="string">`User-added` (a list the user built) or `HRIS-synced` (mirrored from an HR integration).</ResponseField>
+    <ResponseField name="contact_count" type="integer">Number of contacts in the list.</ResponseField>
+  </Expandable>
+</ResponseField>
+<ResponseField name="page" type="integer">The page returned.</ResponseField>
+<ResponseField name="per_page" type="integer">Lists per page.</ResponseField>
+<ResponseField name="total_count" type="integer">Total active lists in the workspace.</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"What contact lists do I have?"
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_contact_lists_list",
+  "arguments": { "workspace_id": "3f8a…" }
+}
+```
+
+```json ↩️ Result
+{
+  "contact_lists": [
+    { "id": "c1e9…", "name": "Q3 onboarding cohort", "kind": "User-added", "contact_count": 12 },
+    { "id": "b730…", "name": "Engineering", "kind": "HRIS-synced", "contact_count": 48 }
+  ],
+  "page": 1,
+  "per_page": 25,
+  "total_count": 2
+}
+```
+</CodeGroup>
+
+<Tip>
+  No list yet? Build one with [`goody_contact_lists_create`](/mcp-reference/tools/contact-lists-create), then point an
+  [`goody_autogift_rules_create`](/mcp-reference/tools/autogift-rules-create) rule at it.
+</Tip>

--- a/mcp-reference/tools/contacts-create.mdx
+++ b/mcp-reference/tools/contacts-create.mdx
@@ -1,0 +1,109 @@
+---
+title: "goody_contacts_create"
+sidebarTitle: "contacts_create"
+description: "Add a new contact to a workspace and return the saved record."
+---
+
+**Permission:** `Write` · **Workspace:** required (from `goody_workspaces_list`)
+
+Creates a contact in the workspace. Only `first_name` is required; everything else is optional. Returns the saved contact.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. The contact is created in this workspace.
+</ParamField>
+
+<ParamField body="first_name" type="string" required>
+  The contact's given name.
+</ParamField>
+
+<ParamField body="last_name" type="string">
+  Family name.
+</ParamField>
+
+<ParamField body="email" type="string">
+  Email address.
+</ParamField>
+
+<ParamField body="phone" type="string">
+  Phone number in any format — it's normalized automatically.
+</ParamField>
+
+<ParamField body="company" type="string">
+  Company name.
+</ParamField>
+
+<ParamField body="title" type="string">
+  Job title.
+</ParamField>
+
+<ParamField body="birthday" type="string">
+  Date as `YYYY-MM-DD`. Use year `1900` if only the month and day are known.
+</ParamField>
+
+<ParamField body="work_anniversary" type="string">
+  Date as `YYYY-MM-DD`. Use year `1900` if only the month and day are known.
+</ParamField>
+
+<Warning>
+  If a contact with the same email or phone already exists in this workspace, the request is rejected rather than overwriting the existing contact. Call [`goody_contacts_update`](/mcp-reference/tools/contacts-update) to modify that contact instead.
+</Warning>
+
+## Returns
+
+<ResponseField name="contact" type="object">
+  The saved contact.
+  <Expandable title="contact">
+    <ResponseField name="id" type="string">Contact UUID.</ResponseField>
+    <ResponseField name="first_name" type="string | null">Given name.</ResponseField>
+    <ResponseField name="last_name" type="string | null">Family name.</ResponseField>
+    <ResponseField name="email" type="string | null">Email address.</ResponseField>
+    <ResponseField name="phone" type="string | null">Phone number.</ResponseField>
+    <ResponseField name="company" type="string | null">Company name.</ResponseField>
+    <ResponseField name="title" type="string | null">Job title.</ResponseField>
+    <ResponseField name="birthday" type="string | null">Date as `YYYY-MM-DD`; year `1900` means month and day only.</ResponseField>
+    <ResponseField name="work_anniversary" type="string | null">Date as `YYYY-MM-DD`.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Add James Okafor (james@northwind.com) to my workspace."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_contacts_create",
+  "arguments": {
+    "workspace_id": "3f8a…",
+    "first_name": "James",
+    "last_name": "Okafor",
+    "email": "james@northwind.com"
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "contact": {
+    "id": "a1d7…",
+    "first_name": "James",
+    "last_name": "Okafor",
+    "email": "james@northwind.com",
+    "phone": null,
+    "company": null,
+    "title": null,
+    "birthday": null,
+    "work_anniversary": null
+  }
+}
+```
+</CodeGroup>
+
+<Tip>
+  To edit a contact you already have, use [`goody_contacts_update`](/mcp-reference/tools/contacts-update). To find one first, use
+  [`goody_contacts_search`](/mcp-reference/tools/contacts-search).
+</Tip>

--- a/mcp-reference/tools/contacts-get.mdx
+++ b/mcp-reference/tools/contacts-get.mdx
@@ -1,0 +1,69 @@
+---
+title: "goody_contacts_get"
+sidebarTitle: "contacts_get"
+description: "Fetch one contact's full detail, including birthday and work anniversary."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Fetches the full detail for a single contact, including the event dates the search response omits. Use it before composing a birthday or anniversary gift, or to confirm a recipient's details before sending.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. The contact must belong to this workspace.
+</ParamField>
+
+<ParamField body="contact_id" type="string" required>
+  Contact UUID — from a [`goody_contacts_search`](/mcp-reference/tools/contacts-search) result.
+</ParamField>
+
+## Returns
+
+<ResponseField name="id" type="string">Contact UUID.</ResponseField>
+<ResponseField name="first_name" type="string | null">Given name.</ResponseField>
+<ResponseField name="last_name" type="string | null">Family name.</ResponseField>
+<ResponseField name="email" type="string | null">Email address.</ResponseField>
+<ResponseField name="phone" type="string | null">Phone number.</ResponseField>
+<ResponseField name="company" type="string | null">Company name.</ResponseField>
+<ResponseField name="title" type="string | null">Job title.</ResponseField>
+<ResponseField name="birthday" type="string | null">Date as `YYYY-MM-DD`. A year of `1900` means only the month and day are known.</ResponseField>
+<ResponseField name="work_anniversary" type="string | null">Date as `YYYY-MM-DD`.</ResponseField>
+
+<Note>
+  Returns not-found if the id is unknown or belongs to another workspace.
+</Note>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"When is Maya Patel's birthday?"
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_contacts_get",
+  "arguments": { "workspace_id": "3f8a…", "contact_id": "9c44…" }
+}
+```
+
+```json ↩️ Result
+{
+  "id": "9c44…",
+  "first_name": "Maya",
+  "last_name": "Patel",
+  "email": "maya@northwind.com",
+  "phone": "+14155550199",
+  "company": "Northwind",
+  "title": "Design Lead",
+  "birthday": "1991-04-12",
+  "work_anniversary": "2020-09-01"
+}
+```
+</CodeGroup>
+
+<Tip>
+  Find the contact first with [`goody_contacts_search`](/mcp-reference/tools/contacts-search), then edit it with
+  [`goody_contacts_update`](/mcp-reference/tools/contacts-update).
+</Tip>

--- a/mcp-reference/tools/contacts-search.mdx
+++ b/mcp-reference/tools/contacts-search.mdx
@@ -1,0 +1,78 @@
+---
+title: "goody_contacts_search"
+sidebarTitle: "contacts_search"
+description: "Find a workspace contact by name, email, or phone — returns up to 25 matches."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Searches the contacts in a workspace and returns up to `limit` matches. Use it to find a recipient before pricing or sending a gift. Match a free-text `query` across name, email, and phone — or omit it to list everyone alphabetically.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Search is always scoped to this workspace.
+</ParamField>
+
+<ParamField body="query" type="string">
+  Free-text search matched across first name, last name, email, and phone. Name matches outrank email matches, which outrank phone matches. Omit to list contacts alphabetically.
+</ParamField>
+
+<ParamField body="limit" type="integer" default="25">
+  Maximum contacts to return. Range 1–25; higher values are clamped to 25. There's no pagination — narrow `query` instead of raising the limit.
+</ParamField>
+
+## Returns
+
+<ResponseField name="contacts" type="object[]">
+  Up to `limit` matching contacts.
+  <Expandable title="contact">
+    <ResponseField name="id" type="string">Contact UUID — pass as `contact_id` to [`goody_contacts_get`](/mcp-reference/tools/contacts-get) or [`goody_contacts_update`](/mcp-reference/tools/contacts-update).</ResponseField>
+    <ResponseField name="first_name" type="string | null">Given name.</ResponseField>
+    <ResponseField name="last_name" type="string | null">Family name.</ResponseField>
+    <ResponseField name="email" type="string | null">Email address.</ResponseField>
+    <ResponseField name="phone" type="string | null">Phone number.</ResponseField>
+    <ResponseField name="company" type="string | null">Company name.</ResponseField>
+    <ResponseField name="title" type="string | null">Job title.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<Note>
+  The search response omits event dates. To get a contact's birthday or work anniversary, call [`goody_contacts_get`](/mcp-reference/tools/contacts-get).
+</Note>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Find my contact Sarah at Acme."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_contacts_search",
+  "arguments": { "workspace_id": "3f8a…", "query": "Sarah Acme" }
+}
+```
+
+```json ↩️ Result
+{
+  "contacts": [
+    {
+      "id": "7b21…",
+      "first_name": "Sarah",
+      "last_name": "Chen",
+      "email": "sarah@acme.com",
+      "phone": "+14155550148",
+      "company": "Acme",
+      "title": "Head of People"
+    }
+  ]
+}
+```
+</CodeGroup>
+
+<Tip>
+  Once you have a match, call [`goody_contacts_get`](/mcp-reference/tools/contacts-get) for the full detail (including birthday and work anniversary), or
+  [`goody_contacts_update`](/mcp-reference/tools/contacts-update) to edit it.
+</Tip>

--- a/mcp-reference/tools/contacts-update.mdx
+++ b/mcp-reference/tools/contacts-update.mdx
@@ -1,0 +1,112 @@
+---
+title: "goody_contacts_update"
+sidebarTitle: "contacts_update"
+description: "Update an existing contact — only the fields you supply are changed."
+---
+
+**Permission:** `Write` · **Workspace:** required (from `goody_workspaces_list`)
+
+Updates an existing contact. Only the fields you supply are written; omitted fields stay untouched. Returns the saved contact.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. The contact must belong to this workspace.
+</ParamField>
+
+<ParamField body="contact_id" type="string" required>
+  Contact UUID — from [`goody_contacts_search`](/mcp-reference/tools/contacts-search) or [`goody_contacts_get`](/mcp-reference/tools/contacts-get).
+</ParamField>
+
+<ParamField body="first_name" type="string">
+  Given name.
+</ParamField>
+
+<ParamField body="last_name" type="string">
+  Family name.
+</ParamField>
+
+<ParamField body="email" type="string">
+  Email address.
+</ParamField>
+
+<ParamField body="phone" type="string">
+  Phone number in any format — it's normalized automatically.
+</ParamField>
+
+<ParamField body="company" type="string">
+  Company name.
+</ParamField>
+
+<ParamField body="title" type="string">
+  Job title.
+</ParamField>
+
+<ParamField body="birthday" type="string">
+  Date as `YYYY-MM-DD`; use year `1900` if only the month and day are known. Pass an empty string to clear it; omit it entirely to leave it unchanged.
+</ParamField>
+
+<ParamField body="work_anniversary" type="string">
+  Date as `YYYY-MM-DD`. Pass an empty string to clear it; omit it entirely to leave it unchanged.
+</ParamField>
+
+<Warning>
+  If the new email or phone already belongs to a different contact in this workspace, the request is rejected. Re-saving the contact's own current email or phone is fine.
+</Warning>
+
+## Returns
+
+<ResponseField name="contact" type="object">
+  The saved contact.
+  <Expandable title="contact">
+    <ResponseField name="id" type="string">Contact UUID.</ResponseField>
+    <ResponseField name="first_name" type="string | null">Given name.</ResponseField>
+    <ResponseField name="last_name" type="string | null">Family name.</ResponseField>
+    <ResponseField name="email" type="string | null">Email address.</ResponseField>
+    <ResponseField name="phone" type="string | null">Phone number.</ResponseField>
+    <ResponseField name="company" type="string | null">Company name.</ResponseField>
+    <ResponseField name="title" type="string | null">Job title.</ResponseField>
+    <ResponseField name="birthday" type="string | null">Date as `YYYY-MM-DD`; year `1900` means month and day only.</ResponseField>
+    <ResponseField name="work_anniversary" type="string | null">Date as `YYYY-MM-DD`.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Update Maya's email to maya@northwind.io."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_contacts_update",
+  "arguments": {
+    "workspace_id": "3f8a…",
+    "contact_id": "9c44…",
+    "email": "maya@northwind.io"
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "contact": {
+    "id": "9c44…",
+    "first_name": "Maya",
+    "last_name": "Patel",
+    "email": "maya@northwind.io",
+    "phone": "+14155550199",
+    "company": "Northwind",
+    "title": "Design Lead",
+    "birthday": "1991-04-12",
+    "work_anniversary": "2020-09-01"
+  }
+}
+```
+</CodeGroup>
+
+<Tip>
+  Find the contact first with [`goody_contacts_search`](/mcp-reference/tools/contacts-search), or read its current detail with
+  [`goody_contacts_get`](/mcp-reference/tools/contacts-get).
+</Tip>

--- a/mcp-reference/tools/feedback-create.mdx
+++ b/mcp-reference/tools/feedback-create.mdx
@@ -1,0 +1,75 @@
+---
+title: "goody_feedback_create"
+sidebarTitle: "feedback_create"
+description: "Send the user's feedback about Goody to the Goody team."
+---
+
+**Permission:** `Write` · **Workspace:** optional
+
+Sends the user's feedback about Goody to the Goody team — a comment, suggestion, bug report, or reaction. This tool never sends a gift or charges anything. It's a good thing to offer after a successful send ("Want me to pass any feedback to the Goody team?").
+
+## Parameters
+
+<ParamField body="message" type="string" required>
+  The feedback, in the user's own words.
+</ParamField>
+
+<ParamField body="sentiment" type="string">
+  How the user feels — one of `positive`, `neutral`, or `negative`.
+</ParamField>
+
+<ParamField body="workspace_id" type="string">
+  Optional. Associates the feedback with a workspace — from `goody_workspaces_list`.
+</ParamField>
+
+<ParamField body="order_batch_id" type="string">
+  Optional. Ties the feedback to a specific gift batch the user is reacting to — from [`goody_order_batches_list`](/mcp-reference/tools/order-batches-list).
+</ParamField>
+
+## Returns
+
+<ResponseField name="feedback" type="object">
+  The recorded feedback.
+  <Expandable title="feedback">
+    <ResponseField name="id" type="string">Feedback UUID.</ResponseField>
+    <ResponseField name="message" type="string">The feedback message as recorded.</ResponseField>
+    <ResponseField name="sentiment" type="string | null">The sentiment, if one was given.</ResponseField>
+    <ResponseField name="created_at" type="string">When the feedback was recorded.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="confirmation" type="string">A short confirmation message to relay to the user.</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Tell the Goody team the preview link was super helpful."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_feedback_create",
+  "arguments": {
+    "message": "The preview link was super helpful.",
+    "sentiment": "positive"
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "feedback": {
+    "id": "f10c…",
+    "message": "The preview link was super helpful.",
+    "sentiment": "positive",
+    "created_at": "2026-06-23T16:40:00Z"
+  },
+  "confirmation": "Thanks — your feedback has been sent to the Goody team."
+}
+```
+</CodeGroup>
+
+<Tip>
+  After a successful send with [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create), pass along the `order_batch_id` here to tie a reaction to that specific gift.
+</Tip>

--- a/mcp-reference/tools/gift-of-choice-list.mdx
+++ b/mcp-reference/tools/gift-of-choice-list.mdx
@@ -1,0 +1,82 @@
+---
+title: "goody_gift_of_choice_list"
+sidebarTitle: "gift_of_choice_list"
+description: "Lists Goody's Gifts of Choice — flex gifts where the recipient picks and the sender funds an amount."
+---
+
+**Permission:** `Read` · **Workspace:** not required (global)
+
+Lists Goody's Gifts of Choice — variable-amount flex gifts where the recipient picks from a curated set and the sender funds an amount. Use when the user wants to "let the recipient choose" or is unsure what to send.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string">
+  Optional. The catalog is global — pass a workspace UUID only to scope or validate against a workspace.
+</ParamField>
+
+<ParamField body="budget_cents" type="integer">
+  Optional, in cents (e.g. `7500` for $75); must be positive. When set, each result's `suggested_variable_price` echoes the fundable amount — your budget clamped to the gift's range.
+</ParamField>
+
+## Returns
+
+<ResponseField name="gifts_of_choice" type="object[]">
+  Matching Gifts of Choice.
+  <Expandable title="gift_of_choice">
+    <ResponseField name="id" type="string">Gift UUID — pass as `product_id` to send.</ResponseField>
+    <ResponseField name="name" type="string">Gift name.</ResponseField>
+    <ResponseField name="kind" type="string">`default` or `seasonal`.</ResponseField>
+    <ResponseField name="price_min" type="integer | null">Lowest fundable amount, in cents.</ResponseField>
+    <ResponseField name="price_max" type="integer | null">Highest fundable amount; `null` means unlimited.</ResponseField>
+    <ResponseField name="suggested_variable_price" type="integer | null">Your budget clamped to `[price_min, price_max]`; `null` if the budget is below `price_min` or no budget was given.</ResponseField>
+    <ResponseField name="occasions" type="string[]">Occasion tags for this gift.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<Note>
+  To send one, pass its `id` as `product_id` plus `variable_price` (cents, within the range) to [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create).
+</Note>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"I don't know their taste — give me a $75 let-them-pick option."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_gift_of_choice_list",
+  "arguments": { "budget_cents": 7500 }
+}
+```
+
+```json ↩️ Result
+{
+  "gifts_of_choice": [
+    {
+      "id": "0f3c…",
+      "name": "Gift of Choice",
+      "kind": "default",
+      "price_min": 2000,
+      "price_max": null,
+      "suggested_variable_price": 7500,
+      "occasions": ["Thank You", "Congratulations"]
+    },
+    {
+      "id": "9a17…",
+      "name": "Holiday Gift of Choice",
+      "kind": "seasonal",
+      "price_min": 5000,
+      "price_max": 25000,
+      "suggested_variable_price": 7500,
+      "occasions": ["Happy Holidays"]
+    }
+  ]
+}
+```
+</CodeGroup>
+
+<Tip>
+  Browse fixed-price gifts with [`goody_products_search`](/mcp-reference/tools/products-search), then send the chosen gift with [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create).
+</Tip>

--- a/mcp-reference/tools/me-get.mdx
+++ b/mcp-reference/tools/me-get.mdx
@@ -1,0 +1,68 @@
+---
+title: "goody_me_get"
+sidebarTitle: "me_get"
+description: "Returns the connected Goody account's identity plus the server's current time."
+---
+
+**Permission:** `Read` · **Workspace:** not required (global)
+
+Returns the authenticated Goody user's identity plus the server's current time. The first tool to call in a session to confirm which account is connected, and the anchor for any relative dates.
+
+## Parameters
+
+This tool takes no arguments.
+
+## Returns
+
+<ResponseField name="id" type="string">
+  The Goody user's UUID.
+</ResponseField>
+
+<ResponseField name="email" type="string">
+  The account's email address.
+</ResponseField>
+
+<ResponseField name="first_name" type="string | null">
+  Given name, if set.
+</ResponseField>
+
+<ResponseField name="last_name" type="string | null">
+  Family name, if set.
+</ResponseField>
+
+<ResponseField name="server_time" type="string">
+  The server's authoritative "now", as an ISO 8601 UTC timestamp.
+</ResponseField>
+
+<Note>
+  Scheduled-send dates are anchored to `server_time` — not the assistant's own clock. A scheduled date must be in the future and at most 3 months out.
+</Note>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Which Goody account am I connected to?"
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_me_get",
+  "arguments": {}
+}
+```
+
+```json ↩️ Result
+{
+  "id": "0f3c…",
+  "email": "jordan@northwind.example",
+  "first_name": "Jordan",
+  "last_name": "Rivera",
+  "server_time": "2026-06-23T14:05:00Z"
+}
+```
+</CodeGroup>
+
+<Tip>
+  Call [`goody_workspaces_list`](/mcp-reference/tools/workspaces-list) next to discover the workspaces this account can gift from.
+</Tip>

--- a/mcp-reference/tools/messages-generate.mdx
+++ b/mcp-reference/tools/messages-generate.mdx
@@ -1,0 +1,77 @@
+---
+title: "goody_messages_generate"
+sidebarTitle: "messages_generate"
+description: "Draft three candidate gift-card messages for the user to pick from or refine."
+---
+
+**Permission:** `Read` · **Workspace:** not required (global)
+
+Generates three candidate gift-card messages for the user to pick from or refine. It works two ways — **autopilot** (`category` + `sub_category`) and **collaborative** (`user_prompt`) — and you can combine them: a category plus free-text instructions.
+
+Built-in categories include thank you, congratulations, birthday, work anniversary, welcome/onboarding, apology, sympathy, farewell, and holidays.
+
+## Parameters
+
+<ParamField body="category" type="string">
+  A message category for autopilot mode — pair with `sub_category` (e.g. `category` `"birthday"`). One of: thank you, congratulations, birthday, work anniversary, welcome/onboarding, apology, sympathy, farewell, or holidays.
+</ParamField>
+
+<ParamField body="sub_category" type="string">
+  A narrower variant within the chosen `category`. Use alongside `category` in autopilot mode.
+</ParamField>
+
+<ParamField body="user_prompt" type="string">
+  Free text describing the message you want — e.g. "thank a client for sticking with us through a delay". Required for collaborative mode; optional in autopilot mode as extra instructions on top of the category.
+</ParamField>
+
+<ParamField body="tones" type="string[]" default="empty">
+  Free-text tone hints, e.g. `["warm", "professional"]`. Defaults to empty.
+</ParamField>
+
+<ParamField body="formality_level" type="integer" default="3">
+  How formal the message should read, from `1` (very casual) to `5` (formal). Defaults to `3`.
+</ParamField>
+
+## Returns
+
+<ResponseField name="messages" type="string[]">
+  Exactly three candidate messages. Show them to the user and let them pick or refine.
+</ResponseField>
+
+<Note>
+  Generated messages may contain the placeholder tokens `{{firstname}}` and `{{fullname}}` — Goody fills in each recipient's real name at send time. Pass the chosen message through to [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create) with the tokens unchanged. When you **show** a message to the user, render the token with the recipient's actual name for a clean preview.
+</Note>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Draft a warm thank-you message for a client."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_messages_generate",
+  "arguments": {
+    "category": "thank you",
+    "user_prompt": "thank a client for sticking with us through a delay",
+    "tones": ["warm", "professional"],
+    "formality_level": 3
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "messages": [
+    "Thank you for your patience through the delay, {{firstname}} — your trust means everything to us, and we're grateful to keep working together.",
+    "{{firstname}}, we know the wait wasn't easy. Thank you for sticking with us — here's to a smoother road ahead.",
+    "A small thank-you, {{firstname}}, for your understanding and continued partnership. We don't take it for granted."
+  ]
+}
+```
+</CodeGroup>
+
+<Tip>
+  Once the user picks a message, carry the tokens through unchanged to [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create) — Goody personalizes each recipient's name at send time.
+</Tip>

--- a/mcp-reference/tools/order-batches-create.mdx
+++ b/mcp-reference/tools/order-batches-create.mdx
@@ -1,0 +1,223 @@
+---
+title: "goody_order_batches_create"
+sidebarTitle: "order_batches_create"
+description: "Send a gift batch — charges the payment method and generates the gift links."
+---
+
+**Permission:** `Send gifts` · **Workspace:** required (from `goody_workspaces_list`)
+
+Sends a gift batch — charges the payment method and generates the gift links.
+
+<Warning>
+  This spends real money and cannot be undone from here. Preview or price first, relay the total, and only call this **after** the user confirms both the price and the recipients.
+</Warning>
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Charges and sends from this workspace.
+</ParamField>
+
+<ParamField body="payment_method_id" type="string" required>
+  The funding source — from [`goody_payment_methods_list`](/mcp-reference/tools/payment-methods-list). A saved-card UUID, or the literal `BALANCE`, `WORKSPACE_BALANCE`, or `CORPORATE_ACCOUNT` sentinel.
+</ParamField>
+
+<ParamField body="card_id" type="string" required>
+  Card UUID — from [`goody_cards_list`](/mcp-reference/tools/cards-list). The card the recipient sees with the gift.
+</ParamField>
+
+<ParamField body="confirmed" type="boolean" required>
+  Must be the literal `true` — the tool rejects anything else. Pass `true` only after the user has approved the price and recipients.
+</ParamField>
+
+<ParamField body="send_method" type="string" required>
+  How each recipient receives the gift. **No default — you must choose one:**
+
+  - `link_single` — the recipient is **not** auto-notified; you share the link yourself.
+  - `email_and_link` — Goody emails each recipient their gift link.
+  - `direct_send` — Goody ships the physical product to each recipient's `mailing_address`, with no email. The `contact_id` shorthand can't be combined with `direct_send`.
+</ParamField>
+
+<ParamField body="product_id" type="string">
+  A single product UUID — from [`goody_products_search`](/mcp-reference/tools/products-search). Use this **or** `cart`, never both.
+</ParamField>
+
+<ParamField body="quantity" type="integer" default="1">
+  Quantity for `product_id`. Defaults to `1`.
+</ParamField>
+
+<ParamField body="variable_price" type="integer">
+  Amount to fund, in cents, for a variable-amount Gift of Choice or variable gift card. Must fall within the gift's `[price_min, price_max]`. Only applies to `product_id`.
+</ParamField>
+
+<ParamField body="cart" type="object">
+  A multi-item cart — an object with an `items` array (not a bare array). Use this **or** `product_id`, never both.
+  <Expandable title="cart">
+    <ParamField body="items" type="object[]" required>
+      One entry per product in the gift.
+      <Expandable title="item">
+        <ParamField body="product_id" type="string" required>Product UUID.</ParamField>
+        <ParamField body="quantity" type="integer" default="1">Quantity of this product.</ParamField>
+        <ParamField body="variable_price" type="integer">Amount in cents for a variable-amount gift, within its `[price_min, price_max]`.</ParamField>
+        <ParamField body="variants" type="string[]">Selected variant option IDs (e.g. size, color) for products that offer them.</ParamField>
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="contact_id" type="string">
+  A single saved-contact UUID — from [`goody_contacts_search`](/mcp-reference/tools/contacts-search). Use this **or** `recipients`. Cannot be combined with `direct_send`.
+</ParamField>
+
+<ParamField body="recipients" type="object[]">
+  The people to send to. Use this **or** `contact_id`.
+  <Expandable title="recipient">
+    <ParamField body="name" type="string">
+      Full name — split on the **first** space (first token → first name, the rest → last name). Use this or `first_name` + `last_name`.
+    </ParamField>
+    <ParamField body="first_name" type="string">First name. Pair with `last_name`.</ParamField>
+    <ParamField body="last_name" type="string">Last name.</ParamField>
+    <ParamField body="email" type="string">Recipient email.</ParamField>
+    <ParamField body="phone" type="string">Recipient phone, when sending by text.</ParamField>
+    <ParamField body="contact_id" type="string">Link this recipient to an existing saved contact.</ParamField>
+    <ParamField body="mailing_address" type="object">
+      Required on every recipient when `send_method` is `direct_send`.
+      <Expandable title="mailing_address">
+        <ParamField body="first_name" type="string">Recipient first name for the shipping label.</ParamField>
+        <ParamField body="last_name" type="string">Recipient last name for the shipping label.</ParamField>
+        <ParamField body="address_1" type="string" required>Street address.</ParamField>
+        <ParamField body="address_2" type="string">Apartment, suite, etc.</ParamField>
+        <ParamField body="city" type="string" required>City.</ParamField>
+        <ParamField body="state" type="string" required>State or province.</ParamField>
+        <ParamField body="postal_code" type="string" required>ZIP or postal code.</ParamField>
+        <ParamField body="country" type="string" required>Country.</ParamField>
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="message" type="string">
+  The note shown on the gift card. Use [`goody_messages_generate`](/mcp-reference/tools/messages-generate) to draft one.
+</ParamField>
+
+<ParamField body="from_name" type="string">
+  The "From" name the recipient sees. Defaults to the authenticated user.
+</ParamField>
+
+<ParamField body="swap" type="string" default="single">
+  Whether the recipient may swap the gift. One of `single` (swap once), `multiple` (swap freely), or `disabled` (no swapping).
+</ParamField>
+
+<ParamField body="scheduled_send_on" type="string">
+  ISO 8601 datetime to delay sending. Must be in the future and at most 3 months out — anchor "now" to [`goody_me_get`](/mcp-reference/tools/me-get)'s `server_time`.
+</ParamField>
+
+<ParamField body="expires_at" type="string">
+  ISO 8601 datetime the gift expires if the recipient hasn't accepted it. **Required when paying from `BALANCE`.** The standard default is about 10 weeks. Mutually exclusive with `expires_on`.
+</ParamField>
+
+<ParamField body="expires_on" type="string">
+  Date alias `YYYY-MM-DD`, coerced to end of day. Mutually exclusive with `expires_at`.
+</ParamField>
+
+<ParamField body="alcohol_age_verification_attested" type="boolean">
+  Must be `true` when the cart contains alcohol.
+</ParamField>
+
+<ParamField body="international_shipping_tier" type="string" default="disabled">
+  How far the gift can ship. One of `disabled` (default; US & Canada only), `standard`, or `full` (global, 140+ countries; up to about $55/order in taxes, tariffs, and freight).
+</ParamField>
+
+<ParamField body="international_gift_cards_enabled" type="boolean">
+  Lets recipients outside supported regions swap their gift for a gift card.
+</ParamField>
+
+<ParamField body="custom_form_id" type="string">
+  Attach an existing custom form's recipient questions to the gift.
+</ParamField>
+
+<Note>
+  **Alcohol gifts** require the account to be alcohol-enabled, cannot be paid from `BALANCE`, and require `alcohol_age_verification_attested: true`.
+</Note>
+
+## Returns
+
+<ResponseField name="order_batch" type="object">
+  The created batch.
+  <Expandable title="order_batch">
+    <ResponseField name="id" type="string">Batch UUID — pass as `order_batch_id` to [`goody_order_batches_get`](/mcp-reference/tools/order-batches-get) or [`goody_orders_list`](/mcp-reference/tools/orders-list).</ResponseField>
+    <ResponseField name="public_id" type="string">The batch's public identifier.</ResponseField>
+    <ResponseField name="status" type="string">Where the batch is in its lifecycle.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="preview_url" type="string | null">
+  A shareable URL that renders the sent gift. **Lead your reply with this.**
+</ResponseField>
+
+<ResponseField name="sender_preview_urls" type="string[]">
+  Per-recipient sender-view links.
+</ResponseField>
+
+<ResponseField name="payment_method" type="object | null">
+  The funding source that was charged.
+  <Expandable title="payment_method">
+    <ResponseField name="id" type="string">The payment-method UUID, or the `BALANCE` / `WORKSPACE_BALANCE` / `CORPORATE_ACCOUNT` sentinel.</ResponseField>
+    <ResponseField name="name" type="string">Display name, e.g. "Visa 1234".</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="notification_summary" type="string | null">
+  Whether and how recipients were notified. State this to the user.
+</ResponseField>
+
+<ResponseField name="suggested_next_steps" type="string[]">
+  Follow-on actions you can offer the user.
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Yes, send it."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_order_batches_create",
+  "arguments": {
+    "workspace_id": "3f8a…",
+    "confirmed": true,
+    "card_id": "7c20…",
+    "payment_method_id": "c41d…",
+    "product_id": "0f3c…",
+    "contact_id": "5b6e…",
+    "send_method": "email_and_link",
+    "message": "Thanks for everything this quarter, Sarah!",
+    "from_name": "Jordan at Acme"
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "order_batch": {
+    "id": "b92e…",
+    "public_id": "gift_2f9c…",
+    "status": "sent"
+  },
+  "preview_url": "https://www.ongoody.com/preview/2f9c…",
+  "sender_preview_urls": ["https://www.ongoody.com/s/8d41…"],
+  "payment_method": { "id": "c41d…", "name": "Visa 1234" },
+  "notification_summary": "Goody emailed Sarah Chen a link to claim her gift.",
+  "suggested_next_steps": [
+    "Track whether Sarah opens her gift with goody_orders_list.",
+    "Set this up to recur for future occasions with goody_autogift_rules_create."
+  ]
+}
+```
+</CodeGroup>
+
+<Tip>
+  Build the confirmation step with [`goody_order_batches_preview`](/mcp-reference/tools/order-batches-preview) before calling this. To make a one-off gift recurring, offer [`goody_autogift_rules_create`](/mcp-reference/tools/autogift-rules-create).
+</Tip>

--- a/mcp-reference/tools/order-batches-get.mdx
+++ b/mcp-reference/tools/order-batches-get.mdx
@@ -1,0 +1,113 @@
+---
+title: "goody_order_batches_get"
+sidebarTitle: "order_batches_get"
+description: "Fetch full detail for a single gift batch — cart, recipients, and send timing."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Fetches full detail for a single gift batch — read back the cart, see who received it, or check scheduled-send timing.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. The batch must belong to this workspace.
+</ParamField>
+
+<ParamField body="order_batch_id" type="string" required>
+  Batch UUID — from [`goody_order_batches_list`](/mcp-reference/tools/order-batches-list).
+</ParamField>
+
+## Returns
+
+<ResponseField name="id" type="string">Batch UUID.</ResponseField>
+<ResponseField name="batch_name" type="string | null">The batch's name.</ResponseField>
+<ResponseField name="send_status" type="string">Where the batch is in its lifecycle.</ResponseField>
+<ResponseField name="from_name" type="string | null">The "From" name recipients see.</ResponseField>
+<ResponseField name="message" type="string | null">The gift-card message.</ResponseField>
+<ResponseField name="orders_count" type="integer">Number of orders in the batch.</ResponseField>
+<ResponseField name="orders_preview" type="object[]">Up to 10 orders from the batch, for a quick look.</ResponseField>
+<ResponseField name="recipients_count" type="integer">Number of recipients.</ResponseField>
+<ResponseField name="recipients_preview" type="object[]">Up to 10 recipients, for a quick look.</ResponseField>
+<ResponseField name="cart" type="object | null">The gift contents (products) for the batch.</ResponseField>
+<ResponseField name="sender" type="object | null">
+  Who sent the batch.
+  <Expandable title="sender">
+    <ResponseField name="first_name" type="string">Sender's given name.</ResponseField>
+    <ResponseField name="last_name" type="string">Sender's family name.</ResponseField>
+    <ResponseField name="email" type="string">Sender's email.</ResponseField>
+  </Expandable>
+</ResponseField>
+<ResponseField name="is_scheduled_send" type="boolean | null">True if the batch is set to send at a future time.</ResponseField>
+<ResponseField name="scheduled_send_on" type="string | null">When the batch is scheduled to send.</ResponseField>
+<ResponseField name="expires_at" type="string | null">When the gift expires. `null` means it does not expire on a fixed date.</ResponseField>
+<ResponseField name="send_method" type="string | null">How recipients are notified.</ResponseField>
+<ResponseField name="card_id" type="string | null">The gift card chosen for the batch.</ResponseField>
+<ResponseField name="workspace_id" type="string | null">The workspace the batch belongs to.</ResponseField>
+<ResponseField name="workspace_name" type="string | null">The workspace's name.</ResponseField>
+<ResponseField name="reference_id" type="string | null">Caller-supplied reference, if one was set.</ResponseField>
+<ResponseField name="preview_url" type="string | null">The sender's "see what you sent" link.</ResponseField>
+<ResponseField name="sender_preview_urls" type="string[]">Per-recipient preview links for the sender.</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Show me the details of that batch."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_order_batches_get",
+  "arguments": { "workspace_id": "3f8a…", "order_batch_id": "b92e…" }
+}
+```
+
+```json ↩️ Result
+{
+  "id": "b92e…",
+  "batch_name": "Q2 client thank-yous",
+  "send_status": "sent",
+  "from_name": "Jordan at Acme",
+  "message": "Thank you for a great quarter, {{firstname}}!",
+  "orders_count": 12,
+  "orders_preview": [
+    { "id": "1c4d…", "recipient_first_name": "Sarah", "status": "accepted" }
+  ],
+  "recipients_count": 12,
+  "recipients_preview": [
+    { "first_name": "Sarah", "last_name": "Chen", "email": "sarah@acme.com" }
+  ],
+  "cart": {
+    "items": [
+      { "product_id": "0f3c…", "name": "Cold Brew Starter Kit" }
+    ]
+  },
+  "sender": {
+    "first_name": "Jordan",
+    "last_name": "Lee",
+    "email": "jordan@acme.com"
+  },
+  "is_scheduled_send": false,
+  "scheduled_send_on": null,
+  "expires_at": null,
+  "send_method": "email",
+  "card_id": "a7f9…",
+  "workspace_id": "3f8a…",
+  "workspace_name": "Acme",
+  "reference_id": null,
+  "preview_url": "https://ongoody.com/g/b92e…",
+  "sender_preview_urls": [
+    "https://ongoody.com/g/b92e…/1c4d…"
+  ]
+}
+```
+</CodeGroup>
+
+<Note>
+  You'll get a not-found error if the id is unknown or belongs to another workspace.
+</Note>
+
+<Tip>
+  To browse other batches, use [`goody_order_batches_list`](/mcp-reference/tools/order-batches-list); to list every individual order inside this batch, use [`goody_orders_list`](/mcp-reference/tools/orders-list).
+</Tip>

--- a/mcp-reference/tools/order-batches-list.mdx
+++ b/mcp-reference/tools/order-batches-list.mdx
@@ -1,0 +1,90 @@
+---
+title: "goody_order_batches_list"
+sidebarTitle: "order_batches_list"
+description: "List previously-sent gift batches in a workspace, most recent first."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Lists previously-sent gift batches in a workspace, most recent first. This is how you answer "what did I send recently?".
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Listing is always scoped to this workspace.
+</ParamField>
+
+<ParamField body="page" type="integer" default="1">
+  Page number, starting at `1`.
+</ParamField>
+
+<ParamField body="per_page" type="integer" default="25">
+  Batches per page. Defaults to `25`, max `100`.
+</ParamField>
+
+## Returns
+
+<ResponseField name="order_batches" type="object[]">
+  Batch summaries, most recent first. Each object also includes additional summary fields beyond those listed here.
+  <Expandable title="order batch">
+    <ResponseField name="id" type="string">Batch UUID — pass as `order_batch_id` to [`goody_order_batches_get`](/mcp-reference/tools/order-batches-get) or [`goody_orders_list`](/mcp-reference/tools/orders-list).</ResponseField>
+    <ResponseField name="batch_name" type="string | null">The batch's name.</ResponseField>
+    <ResponseField name="send_status" type="string">Where the batch is in its lifecycle.</ResponseField>
+    <ResponseField name="from_name" type="string | null">The "From" name recipients see.</ResponseField>
+    <ResponseField name="message" type="string | null">The gift-card message.</ResponseField>
+    <ResponseField name="orders_count" type="integer">Number of orders in the batch.</ResponseField>
+    <ResponseField name="recipients_count" type="integer">Number of recipients.</ResponseField>
+    <ResponseField name="scheduled_send_on" type="string | null">When the batch is scheduled to send, if scheduled.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="total_count" type="integer">
+  Total number of batches across all pages.
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Show me my last few gifts."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_order_batches_list",
+  "arguments": { "workspace_id": "3f8a…", "per_page": 3 }
+}
+```
+
+```json ↩️ Result
+{
+  "order_batches": [
+    {
+      "id": "b92e…",
+      "batch_name": "Q2 client thank-yous",
+      "send_status": "sent",
+      "from_name": "Jordan at Acme",
+      "message": "Thank you for a great quarter, {{firstname}}!",
+      "orders_count": 12,
+      "recipients_count": 12,
+      "scheduled_send_on": null
+    },
+    {
+      "id": "4a07…",
+      "batch_name": "Welcome — new hires",
+      "send_status": "scheduled",
+      "from_name": "The Acme Team",
+      "message": "Welcome aboard, {{firstname}}!",
+      "orders_count": 3,
+      "recipients_count": 3,
+      "scheduled_send_on": "2026-07-01T09:00:00Z"
+    }
+  ],
+  "total_count": 47
+}
+```
+</CodeGroup>
+
+<Tip>
+  For the full detail of one batch use [`goody_order_batches_get`](/mcp-reference/tools/order-batches-get); to list the individual orders inside a batch use [`goody_orders_list`](/mcp-reference/tools/orders-list).
+</Tip>

--- a/mcp-reference/tools/order-batches-preview.mdx
+++ b/mcp-reference/tools/order-batches-preview.mdx
@@ -1,0 +1,150 @@
+---
+title: "goody_order_batches_preview"
+sidebarTitle: "order_batches_preview"
+description: "Build a shareable preview link and price a gift before sending — nothing is charged."
+---
+
+**Permission:** `Write` · **Workspace:** required (from `goody_workspaces_list`)
+
+Builds a shareable preview link **and** prices a gift that has **not** been sent — nothing is charged, nothing is sent. This is the step that lets the user *see* the assembled gift (card, message, products) at a real URL and review the total before sending.
+
+Lead your reply with the `preview_url`, relay the `total_price`, and only after the user confirms call [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create) with the same inputs.
+
+<Note>
+  There is no `payment_method_id` here — previewing neither charges nor needs a funding source.
+</Note>
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Scopes the preview to this workspace.
+</ParamField>
+
+<ParamField body="card_id" type="string" required>
+  Card UUID — from [`goody_cards_list`](/mcp-reference/tools/cards-list). Picking a real card means the preview shows the actual card the recipient will see.
+</ParamField>
+
+<ParamField body="product_id" type="string">
+  A single product UUID — from [`goody_products_search`](/mcp-reference/tools/products-search). Use this **or** `cart`, never both.
+</ParamField>
+
+<ParamField body="quantity" type="integer" default="1">
+  Quantity for `product_id`. Defaults to `1`.
+</ParamField>
+
+<ParamField body="variable_price" type="integer">
+  Amount to fund, in cents, for a variable-amount Gift of Choice or variable gift card. Must fall within the gift's `[price_min, price_max]`. Only applies to `product_id`.
+</ParamField>
+
+<ParamField body="cart" type="object">
+  A multi-item cart — an object with an `items` array (not a bare array). Use this **or** `product_id`, never both.
+  <Expandable title="cart">
+    <ParamField body="items" type="object[]" required>
+      One entry per product in the gift.
+      <Expandable title="item">
+        <ParamField body="product_id" type="string" required>Product UUID.</ParamField>
+        <ParamField body="quantity" type="integer" default="1">Quantity of this product.</ParamField>
+        <ParamField body="variable_price" type="integer">Amount in cents for a variable-amount gift, within its `[price_min, price_max]`.</ParamField>
+        <ParamField body="variants" type="string[]">Selected variant option IDs (e.g. size, color) for products that offer them.</ParamField>
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="contact_id" type="string">
+  A single saved-contact UUID — from [`goody_contacts_search`](/mcp-reference/tools/contacts-search). Use this **or** `recipients`. Optional: omit recipients entirely to preview a half-composed gift with a placeholder recipient.
+</ParamField>
+
+<ParamField body="recipients" type="object[]">
+  The people to send to. Use this **or** `contact_id`. Optional here — omit to preview before recipients are known.
+  <Expandable title="recipient">
+    <ParamField body="name" type="string">
+      Full name — split on the **first** space (first token → first name, the rest → last name). Use this or `first_name` + `last_name`.
+    </ParamField>
+    <ParamField body="first_name" type="string">First name. Pair with `last_name`.</ParamField>
+    <ParamField body="last_name" type="string">Last name.</ParamField>
+    <ParamField body="email" type="string">Recipient email.</ParamField>
+    <ParamField body="phone" type="string">Recipient phone, when sending by text.</ParamField>
+    <ParamField body="contact_id" type="string">Link this recipient to an existing saved contact.</ParamField>
+    <ParamField body="mailing_address" type="object">
+      Required on every recipient when `send_method` is `direct_send`.
+      <Expandable title="mailing_address">
+        <ParamField body="first_name" type="string">Recipient first name for the shipping label.</ParamField>
+        <ParamField body="last_name" type="string">Recipient last name for the shipping label.</ParamField>
+        <ParamField body="address_1" type="string" required>Street address.</ParamField>
+        <ParamField body="address_2" type="string">Apartment, suite, etc.</ParamField>
+        <ParamField body="city" type="string" required>City.</ParamField>
+        <ParamField body="state" type="string" required>State or province.</ParamField>
+        <ParamField body="postal_code" type="string" required>ZIP or postal code.</ParamField>
+        <ParamField body="country" type="string" required>Country.</ParamField>
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="message" type="string">
+  The note shown on the gift card. Use [`goody_messages_generate`](/mcp-reference/tools/messages-generate) to draft one.
+</ParamField>
+
+<ParamField body="from_name" type="string">
+  The "From" name the recipient sees. Defaults to the authenticated user.
+</ParamField>
+
+<ParamField body="send_method" type="string" default="link_single">
+  How the recipient receives the gift. One of `link_single` (you share the link yourself), `email_and_link` (Goody emails each recipient their link), or `direct_send` (ships a physical product to each recipient — requires a `mailing_address` on every recipient).
+</ParamField>
+
+## Returns
+
+<ResponseField name="preview_url" type="string">
+  A shareable URL that renders the assembled gift — card, message, and products. **Lead your reply with this** so the user can see exactly what they're sending.
+</ResponseField>
+
+<ResponseField name="draft_batch_id" type="string">
+  UUID of the draft batch the preview was built from.
+</ResponseField>
+
+<ResponseField name="cart_price" type="object">
+  The cart subtotal before tax and shipping.
+</ResponseField>
+
+<ResponseField name="total_price" type="object">
+  The full total — subtotal, tax, and shipping. Relay this to the user before sending.
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Show me a preview of the Cold Brew Kit for Sarah before sending."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_order_batches_preview",
+  "arguments": {
+    "workspace_id": "3f8a…",
+    "card_id": "7c20…",
+    "product_id": "0f3c…",
+    "recipients": [
+      { "name": "Sarah Chen", "email": "sarah@acme.com" }
+    ],
+    "message": "Thanks for everything this quarter, Sarah!",
+    "from_name": "Jordan at Acme"
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "preview_url": "https://www.ongoody.com/preview/2f9c…",
+  "draft_batch_id": "a18d…",
+  "cart_price": { "subtotal": 4200, "currency": "USD" },
+  "total_price": { "subtotal": 4200, "tax": 357, "shipping": 0, "total": 4557, "currency": "USD" }
+}
+```
+</CodeGroup>
+
+<Tip>
+  When the user confirms, send it with [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create) using the same inputs. For just a number without the link, use [`goody_order_batches_price`](/mcp-reference/tools/order-batches-price); to draft the card message, use [`goody_messages_generate`](/mcp-reference/tools/messages-generate).
+</Tip>

--- a/mcp-reference/tools/order-batches-price.mdx
+++ b/mcp-reference/tools/order-batches-price.mdx
@@ -1,0 +1,154 @@
+---
+title: "goody_order_batches_price"
+sidebarTitle: "order_batches_price"
+description: "Quick price estimate — cart subtotal, tax, shipping, and total — before sending."
+---
+
+**Permission:** `Write` · **Workspace:** required (from `goody_workspaces_list`)
+
+A quick price estimate — cart subtotal, tax, shipping, and total — before sending. Use it when the user just wants a number; use [`goody_order_batches_preview`](/mcp-reference/tools/order-batches-preview) for the richer confirm-against-it step that returns a shareable link. Nothing is charged.
+
+<Note>
+  Relay the total, the `from_name`, and the `notification_preview` before calling [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create).
+</Note>
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Scopes the estimate to this workspace.
+</ParamField>
+
+<ParamField body="product_id" type="string">
+  A single product UUID — from [`goody_products_search`](/mcp-reference/tools/products-search). Use this **or** `cart`, never both.
+</ParamField>
+
+<ParamField body="quantity" type="integer" default="1">
+  Quantity for `product_id`. Defaults to `1`.
+</ParamField>
+
+<ParamField body="variable_price" type="integer">
+  Amount to fund, in cents, for a variable-amount Gift of Choice or variable gift card. Must fall within the gift's `[price_min, price_max]`. Only applies to `product_id`.
+</ParamField>
+
+<ParamField body="cart" type="object">
+  A multi-item cart — an object with an `items` array (not a bare array). Use this **or** `product_id`, never both.
+  <Expandable title="cart">
+    <ParamField body="items" type="object[]" required>
+      One entry per product in the gift.
+      <Expandable title="item">
+        <ParamField body="product_id" type="string" required>Product UUID.</ParamField>
+        <ParamField body="quantity" type="integer" default="1">Quantity of this product.</ParamField>
+        <ParamField body="variable_price" type="integer">Amount in cents for a variable-amount gift, within its `[price_min, price_max]`.</ParamField>
+        <ParamField body="variants" type="string[]">Selected variant option IDs (e.g. size, color) for products that offer them.</ParamField>
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="contact_id" type="string">
+  A single saved-contact UUID — from [`goody_contacts_search`](/mcp-reference/tools/contacts-search). Use this **or** `recipients`.
+</ParamField>
+
+<ParamField body="recipients" type="object[]">
+  The people to send to. Use this **or** `contact_id`.
+  <Expandable title="recipient">
+    <ParamField body="name" type="string">
+      Full name — split on the **first** space (first token → first name, the rest → last name). Use this or `first_name` + `last_name`.
+    </ParamField>
+    <ParamField body="first_name" type="string">First name. Pair with `last_name`.</ParamField>
+    <ParamField body="last_name" type="string">Last name.</ParamField>
+    <ParamField body="email" type="string">Recipient email.</ParamField>
+    <ParamField body="phone" type="string">Recipient phone, when sending by text.</ParamField>
+    <ParamField body="contact_id" type="string">Link this recipient to an existing saved contact.</ParamField>
+    <ParamField body="mailing_address" type="object">
+      Required on every recipient when `send_method` is `direct_send`.
+      <Expandable title="mailing_address">
+        <ParamField body="first_name" type="string">Recipient first name for the shipping label.</ParamField>
+        <ParamField body="last_name" type="string">Recipient last name for the shipping label.</ParamField>
+        <ParamField body="address_1" type="string" required>Street address.</ParamField>
+        <ParamField body="address_2" type="string">Apartment, suite, etc.</ParamField>
+        <ParamField body="city" type="string" required>City.</ParamField>
+        <ParamField body="state" type="string" required>State or province.</ParamField>
+        <ParamField body="postal_code" type="string" required>ZIP or postal code.</ParamField>
+        <ParamField body="country" type="string" required>Country.</ParamField>
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="send_method" type="string" default="link_single">
+  How the recipient receives the gift. One of `link_single`, `email_and_link`, or `direct_send` (ships a physical product — requires a `mailing_address` on every recipient). Affects shipping in the estimate.
+</ParamField>
+
+<ParamField body="swap" type="string" default="single">
+  Whether the recipient may swap the gift. One of `single` (swap once), `multiple` (swap freely), or `disabled` (no swapping).
+</ParamField>
+
+<ParamField body="from_name" type="string">
+  The "From" name the recipient sees. When the user states a From name, pass it. Defaults to the authenticated user.
+</ParamField>
+
+<ParamField body="payment_method_id" type="string">
+  Optional. A funding source — from [`goody_payment_methods_list`](/mcp-reference/tools/payment-methods-list). When supplied, the result echoes the resolved `payment_method` so the user can confirm where the charge would land.
+</ParamField>
+
+## Returns
+
+<ResponseField name="cart_price" type="object">
+  The cart subtotal before tax and shipping.
+</ResponseField>
+
+<ResponseField name="total_price" type="object">
+  The full total — subtotal, tax, and shipping. Relay this to the user.
+</ResponseField>
+
+<ResponseField name="from_name" type="string">
+  The resolved sender name. Show it to the user so they can confirm who the gift is from.
+</ResponseField>
+
+<ResponseField name="notification_preview" type="string">
+  How recipients are reached for the chosen `send_method` (e.g. emailed a link, or shipped directly). State this before sending.
+</ResponseField>
+
+<ResponseField name="payment_method" type="object | null">
+  The resolved funding source — present only when a `payment_method_id` was supplied.
+  <Expandable title="payment_method">
+    <ResponseField name="id" type="string">The payment-method UUID, or the `BALANCE` / `WORKSPACE_BALANCE` / `CORPORATE_ACCOUNT` sentinel.</ResponseField>
+    <ResponseField name="name" type="string">Display name, e.g. "Visa 1234".</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"How much to send the Brightland olive oil set to Jane Doe (jane@acme.com)?"
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_order_batches_price",
+  "arguments": {
+    "workspace_id": "3f8a…",
+    "product_id": "9a17…",
+    "recipients": [
+      { "name": "Jane Doe", "email": "jane@acme.com" }
+    ]
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "cart_price": { "subtotal": 5200, "currency": "USD" },
+  "total_price": { "subtotal": 5200, "tax": 442, "shipping": 0, "total": 5642, "currency": "USD" },
+  "from_name": "Jordan at Acme",
+  "notification_preview": "Goody will email Jane Doe a link to claim the gift.",
+  "payment_method": null
+}
+```
+</CodeGroup>
+
+<Tip>
+  For a shareable preview link the user can review before sending, use [`goody_order_batches_preview`](/mcp-reference/tools/order-batches-preview). When the user confirms, send it with [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create).
+</Tip>

--- a/mcp-reference/tools/orders-cancel.mdx
+++ b/mcp-reference/tools/orders-cancel.mdx
@@ -1,0 +1,68 @@
+---
+title: "goody_orders_cancel"
+sidebarTitle: "orders_cancel"
+description: "Cancel a single order (one recipient's gift) before the recipient accepts it."
+---
+
+**Permission:** `Write` · **Workspace:** required (from `goody_workspaces_list`)
+
+Cancels a single order — one recipient's gift.
+
+<Warning>
+  This is irreversible — it releases the recipient's payment hold and refunds any applied credit. Only orders the recipient has **not** yet accepted can be canceled.
+</Warning>
+
+To cancel a whole batch, call this once per order id from [`goody_orders_list`](/mcp-reference/tools/orders-list).
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Scopes the cancellation to this workspace.
+</ParamField>
+
+<ParamField body="order_id" type="string" required>
+  The order to cancel — an order id from a [`goody_orders_list`](/mcp-reference/tools/orders-list) result.
+</ParamField>
+
+## Returns
+
+<ResponseField name="id" type="string">
+  The order id that was canceled.
+</ResponseField>
+
+<ResponseField name="status" type="string | null">
+  The order status after cancellation.
+</ResponseField>
+
+<Note>
+  A person can also self-serve cancellations on the Goody Track page.
+</Note>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Cancel the gift I sent to that wrong address."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_orders_cancel",
+  "arguments": {
+    "workspace_id": "3f8a…",
+    "order_id": "d72b…"
+  }
+}
+```
+
+```json ↩️ Result
+{
+  "id": "d72b…",
+  "status": "canceled"
+}
+```
+</CodeGroup>
+
+<Tip>
+  Find the order id with [`goody_orders_list`](/mcp-reference/tools/orders-list); for the full detail of the batch it belongs to, use [`goody_order_batches_get`](/mcp-reference/tools/order-batches-get).
+</Tip>

--- a/mcp-reference/tools/orders-list.mdx
+++ b/mcp-reference/tools/orders-list.mdx
@@ -1,0 +1,100 @@
+---
+title: "goody_orders_list"
+sidebarTitle: "orders_list"
+description: "List individual orders (one per recipient), across a workspace or within one batch."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Lists individual orders — one per recipient. Without `order_batch_id`, it lists all orders in the workspace, newest first. With it, it lists the orders in that batch, oldest first.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Listing is always scoped to this workspace.
+</ParamField>
+
+<ParamField body="order_batch_id" type="string">
+  Optional filter to one batch — from [`goody_order_batches_list`](/mcp-reference/tools/order-batches-list). Omit to list all orders in the workspace.
+</ParamField>
+
+<ParamField body="page" type="integer" default="1">
+  Page number, starting at `1`.
+</ParamField>
+
+<ParamField body="per_page" type="integer" default="25">
+  Orders per page. Defaults to `25`, max `100`.
+</ParamField>
+
+## Returns
+
+<ResponseField name="orders" type="object[]">
+  The matching orders, one per recipient.
+  <Expandable title="order">
+    <ResponseField name="id" type="string">Order UUID — pass as `order_id` to [`goody_orders_cancel`](/mcp-reference/tools/orders-cancel).</ResponseField>
+    <ResponseField name="status" type="string">Where the order is in its lifecycle.</ResponseField>
+    <ResponseField name="recipient_first_name" type="string | null">Recipient's given name.</ResponseField>
+    <ResponseField name="recipient_last_name" type="string | null">Recipient's family name.</ResponseField>
+    <ResponseField name="recipient_email" type="string | null">Recipient's email.</ResponseField>
+    <ResponseField name="card_id" type="string | null">The gift card chosen for this order.</ResponseField>
+    <ResponseField name="message" type="string | null">The gift-card message.</ResponseField>
+    <ResponseField name="cart" type="object | null">The gift contents (products).</ResponseField>
+    <ResponseField name="amounts" type="object | null">The order's monetary breakdown.</ResponseField>
+    <ResponseField name="shipments" type="object[]">Shipment records for the order, if any.</ResponseField>
+    <ResponseField name="sender" type="object | null">Who sent the order.</ResponseField>
+    <ResponseField name="workspace_id" type="string | null">The workspace the order belongs to.</ResponseField>
+    <ResponseField name="order_batch_id" type="string | null">The batch this order belongs to.</ResponseField>
+    <ResponseField name="reference_id" type="string | null">Caller-supplied reference, if one was set.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="total_count" type="integer">
+  Total number of orders across all pages.
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Who received the gifts in that batch?"
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_orders_list",
+  "arguments": { "workspace_id": "3f8a…", "order_batch_id": "b92e…" }
+}
+```
+
+```json ↩️ Result
+{
+  "orders": [
+    {
+      "id": "1c4d…",
+      "status": "accepted",
+      "recipient_first_name": "Sarah",
+      "recipient_last_name": "Chen",
+      "recipient_email": "sarah@acme.com",
+      "card_id": "a7f9…",
+      "message": "Thank you for a great quarter, Sarah!",
+      "cart": { "items": [{ "product_id": "0f3c…", "name": "Cold Brew Starter Kit" }] },
+      "amounts": { "subtotal": 4200, "total": 4620 },
+      "shipments": [],
+      "sender": { "first_name": "Jordan", "last_name": "Lee", "email": "jordan@acme.com" },
+      "workspace_id": "3f8a…",
+      "order_batch_id": "b92e…",
+      "reference_id": null
+    }
+  ],
+  "total_count": 12
+}
+```
+</CodeGroup>
+
+<Note>
+  You'll get a not-found error if `order_batch_id` references a batch outside the resolved workspace.
+</Note>
+
+<Tip>
+  For the batch as a whole — cart, "From" name, send timing — use [`goody_order_batches_get`](/mcp-reference/tools/order-batches-get); to cancel an order that hasn't been accepted yet, use [`goody_orders_cancel`](/mcp-reference/tools/orders-cancel).
+</Tip>

--- a/mcp-reference/tools/payment-methods-list.mdx
+++ b/mcp-reference/tools/payment-methods-list.mdx
@@ -1,0 +1,71 @@
+---
+title: "goody_payment_methods_list"
+sidebarTitle: "payment_methods_list"
+description: "List the payment methods the user can charge for a gift in a workspace."
+---
+
+**Permission:** `Read` · **Workspace:** required (from `goody_workspaces_list`)
+
+Lists the payment methods the user can charge for a gift in the given workspace. Call this before sending so the user can confirm the funding source.
+
+## Parameters
+
+<ParamField body="workspace_id" type="string" required>
+  Workspace UUID — from `goody_workspaces_list`. Gates access to the user's payment methods.
+</ParamField>
+
+## Returns
+
+<ResponseField name="items" type="object[]">
+  The payment methods available in this workspace.
+  <Expandable title="payment method">
+    <ResponseField name="id" type="string">A payment-method UUID, or the literal `BALANCE` or `CORPORATE_ACCOUNT`. Pass as `payment_method_id` to [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create).</ResponseField>
+    <ResponseField name="name" type="string">Display name, e.g. "Visa 1234", "Balance", or "Corporate Account".</ResponseField>
+    <ResponseField name="cardholder_name" type="string | null">Name on the card, when applicable.</ResponseField>
+    <ResponseField name="balance" type="integer | null">Cents available to spend. Present only for `BALANCE` and `CORPORATE_ACCOUNT`.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"What can I pay with?"
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_payment_methods_list",
+  "arguments": { "workspace_id": "3f8a…" }
+}
+```
+
+```json ↩️ Result
+{
+  "items": [
+    {
+      "id": "c41d…",
+      "name": "Visa 1234",
+      "cardholder_name": "Jordan Lee",
+      "balance": null
+    },
+    {
+      "id": "BALANCE",
+      "name": "Balance",
+      "cardholder_name": null,
+      "balance": 25000
+    },
+    {
+      "id": "CORPORATE_ACCOUNT",
+      "name": "Corporate Account",
+      "cardholder_name": null,
+      "balance": 480000
+    }
+  ]
+}
+```
+</CodeGroup>
+
+<Tip>
+  Confirm the funding source with the user, then pass the chosen `id` as `payment_method_id` to [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create).
+</Tip>

--- a/mcp-reference/tools/products-get.mdx
+++ b/mcp-reference/tools/products-get.mdx
@@ -1,0 +1,118 @@
+---
+title: "goody_products_get"
+sidebarTitle: "products_get"
+description: "Fetches full detail for a single product, richer than a search result."
+---
+
+**Permission:** `Read` · **Workspace:** not required (global)
+
+Fetches full detail for a single product — richer than a search result. Use it when the user is close to committing and you need the description, shipping tier, alcohol status, or US state restrictions.
+
+## Parameters
+
+<ParamField body="product_id" type="string" required>
+  Product UUID, from a [`goody_products_search`](/mcp-reference/tools/products-search) result.
+</ParamField>
+
+## Returns
+
+<ResponseField name="id" type="string">
+  Product UUID.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  Product name.
+</ResponseField>
+
+<ResponseField name="brand" type="string | null">
+  Brand name.
+</ResponseField>
+
+<ResponseField name="image_key" type="string | null">
+  Opaque image key for the product photo.
+</ResponseField>
+
+<ResponseField name="price_cents" type="integer | null">
+  Price in cents for fixed-price products.
+</ResponseField>
+
+<ResponseField name="description" type="string | null">
+  Full product description.
+</ResponseField>
+
+<ResponseField name="additional_images" type="string[]">
+  Extra image keys beyond the primary photo.
+</ResponseField>
+
+<ResponseField name="shipping_tier" type="string">
+  `domestic_us`, `international`, or `any`.
+</ResponseField>
+
+<ResponseField name="alcohol" type="boolean">
+  True if the product contains alcohol (extra requirements apply to send).
+</ResponseField>
+
+<ResponseField name="restrictions" type="string[]">
+  US state codes where this product can't ship.
+</ResponseField>
+
+<ResponseField name="price_type" type="string | null">
+  `fixed`, `variable`, or `tiers`.
+</ResponseField>
+
+<ResponseField name="is_flex_gift" type="boolean">
+  True for a Gift of Choice (recipient picks; sender funds an amount).
+</ResponseField>
+
+<ResponseField name="price_min" type="integer | null">
+  Lowest amount (cents) the sender may fund, for a Gift of Choice.
+</ResponseField>
+
+<ResponseField name="price_max" type="integer | null">
+  Highest fundable amount; `null` means unlimited.
+</ResponseField>
+
+<Note>
+  Returns a not-found error if the product id is unknown, private, or inactive.
+</Note>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Tell me more about the Cold Brew Starter Kit."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_products_get",
+  "arguments": { "product_id": "0f3c…" }
+}
+```
+
+```json ↩️ Result
+{
+  "id": "0f3c…",
+  "name": "Cold Brew Starter Kit",
+  "brand": "Grady's",
+  "image_key": "products/cold-brew-starter-kit.png",
+  "price_cents": 4200,
+  "description": "Everything to brew smooth cold brew at home: a glass carafe, a reusable filter, and two pouches of coarse-ground beans.",
+  "additional_images": [
+    "products/cold-brew-starter-kit-2.png",
+    "products/cold-brew-starter-kit-3.png"
+  ],
+  "shipping_tier": "domestic_us",
+  "alcohol": false,
+  "restrictions": [],
+  "price_type": "fixed",
+  "is_flex_gift": false,
+  "price_min": null,
+  "price_max": null
+}
+```
+</CodeGroup>
+
+<Tip>
+  Pair with [`goody_products_search`](/mcp-reference/tools/products-search) to discover products, or [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list) when the recipient's taste is unknown.
+</Tip>

--- a/mcp-reference/tools/products-search.mdx
+++ b/mcp-reference/tools/products-search.mdx
@@ -1,0 +1,84 @@
+---
+title: "goody_products_search"
+sidebarTitle: "products_search"
+description: "Search Goody's catalog by intent, budget, and filters — returns up to 5 curated matches."
+---
+
+**Permission:** `Read` · **Service:** discovery
+
+Searches Goody's product catalog and returns up to **5** candidate products. There's no pagination — to refine, call again with tighter filters. This is the discovery half of the gifting flow.
+
+## Parameters
+
+<ParamField body="query" type="string">
+  Free-text intent — recipient interests, vibe, or occasion (e.g. "tea lover", "Vermont maple syrup").
+</ParamField>
+
+<ParamField body="price_min" type="integer">
+  Minimum price, in cents (e.g. `2500` for $25).
+</ParamField>
+
+<ParamField body="price_max" type="integer">
+  Maximum price, in cents.
+</ParamField>
+
+<ParamField body="exclude_alcohol" type="boolean" default="true">
+  Defaults to true. Set false only if the user explicitly asked for alcohol gifts.
+</ParamField>
+
+<ParamField body="shipping_tier" type="string" default="domestic_us">
+  One of `domestic_us` (default), `international` (recipient outside the US), or `any`.
+</ParamField>
+
+<ParamField body="category_id" type="string">
+  UUID of a Goody category. Advanced — usually omitted.
+</ParamField>
+
+## Returns
+
+Up to 5 products. Each carries `id`, `name`, `brand`, `price_cents`, `price_type` (`fixed` / `variable` / `tiers`), `is_flex_gift`, `price_min` / `price_max` (for a Gift of Choice), and `alcohol`.
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"Find a thank-you gift under $50 for a client who loves coffee."
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_products_search",
+  "arguments": { "query": "coffee gift for a client", "price_max": 5000 }
+}
+```
+
+```json ↩️ Result
+{
+  "products": [
+    {
+      "id": "0f3c…",
+      "name": "Cold Brew Starter Kit",
+      "brand": "Grady's",
+      "price_cents": 4200,
+      "price_type": "fixed",
+      "is_flex_gift": false,
+      "alcohol": false
+    },
+    {
+      "id": "9a17…",
+      "name": "Single-Origin Coffee Trio",
+      "brand": "Driftaway Coffee",
+      "price_cents": 3600,
+      "price_type": "fixed",
+      "is_flex_gift": false,
+      "alcohol": false
+    }
+  ]
+}
+```
+</CodeGroup>
+
+<Tip>
+  Pair with `goody_products_get` for richer detail before committing, or
+  `goody_gift_of_choice_list` when the recipient's taste is unknown — let them pick.
+</Tip>

--- a/mcp-reference/tools/products-search.mdx
+++ b/mcp-reference/tools/products-search.mdx
@@ -4,18 +4,20 @@ sidebarTitle: "products_search"
 description: "Search Goody's catalog by intent, budget, and filters — returns up to 5 curated matches."
 ---
 
-**Permission:** `Read` · **Service:** discovery
+**Permission:** `Read` · **Workspace:** not required (global catalog)
 
 Searches Goody's product catalog and returns up to **5** candidate products. There's no pagination — to refine, call again with tighter filters. This is the discovery half of the gifting flow.
+
+Most results are fixed-price SKUs. Some are a **Gift of Choice** (`price_type` `variable`, `is_flex_gift` true): the recipient picks from a curated set and the sender funds any amount within `[price_min, price_max]`. To list Gifts of Choice directly, use [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list).
 
 ## Parameters
 
 <ParamField body="query" type="string">
-  Free-text intent — recipient interests, vibe, or occasion (e.g. "tea lover", "Vermont maple syrup").
+  Free-text intent — recipient interests, vibe, or occasion (e.g. "tea lover", "Vermont maple syrup"). Matched across product name, description, and brand.
 </ParamField>
 
 <ParamField body="price_min" type="integer">
-  Minimum price, in cents (e.g. `2500` for $25).
+  Minimum price, in cents (e.g. `2500` for $25). Strings are accepted and coerced.
 </ParamField>
 
 <ParamField body="price_max" type="integer">
@@ -36,7 +38,21 @@ Searches Goody's product catalog and returns up to **5** candidate products. The
 
 ## Returns
 
-Up to 5 products. Each carries `id`, `name`, `brand`, `price_cents`, `price_type` (`fixed` / `variable` / `tiers`), `is_flex_gift`, `price_min` / `price_max` (for a Gift of Choice), and `alcohol`.
+<ResponseField name="products" type="object[]">
+  Up to 5 matching products.
+  <Expandable title="product">
+    <ResponseField name="id" type="string">Product UUID — pass as `product_id` to [`goody_products_get`](/mcp-reference/tools/products-get), [`goody_order_batches_preview`](/mcp-reference/tools/order-batches-preview), or [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create).</ResponseField>
+    <ResponseField name="name" type="string">Product name.</ResponseField>
+    <ResponseField name="brand" type="string | null">Brand name.</ResponseField>
+    <ResponseField name="image_key" type="string | null">Opaque image key for the product photo.</ResponseField>
+    <ResponseField name="price_cents" type="integer | null">Price in cents for fixed-price products.</ResponseField>
+    <ResponseField name="price_type" type="string | null">`fixed`, `variable`, or `tiers`.</ResponseField>
+    <ResponseField name="is_flex_gift" type="boolean">True for a Gift of Choice (recipient picks; sender funds an amount).</ResponseField>
+    <ResponseField name="price_min" type="integer | null">Lowest amount (cents) the sender may fund, for a Gift of Choice.</ResponseField>
+    <ResponseField name="price_max" type="integer | null">Highest fundable amount; `null` means unlimited.</ResponseField>
+    <ResponseField name="alcohol" type="boolean">True if the product contains alcohol (extra requirements apply to send).</ResponseField>
+  </Expandable>
+</ResponseField>
 
 ## Example
 
@@ -59,18 +75,24 @@ Up to 5 products. Each carries `id`, `name`, `brand`, `price_cents`, `price_type
       "id": "0f3c…",
       "name": "Cold Brew Starter Kit",
       "brand": "Grady's",
+      "image_key": "products/cold-brew-starter-kit.png",
       "price_cents": 4200,
       "price_type": "fixed",
       "is_flex_gift": false,
+      "price_min": null,
+      "price_max": null,
       "alcohol": false
     },
     {
       "id": "9a17…",
       "name": "Single-Origin Coffee Trio",
       "brand": "Driftaway Coffee",
+      "image_key": "products/coffee-trio.png",
       "price_cents": 3600,
       "price_type": "fixed",
       "is_flex_gift": false,
+      "price_min": null,
+      "price_max": null,
       "alcohol": false
     }
   ]
@@ -79,6 +101,6 @@ Up to 5 products. Each carries `id`, `name`, `brand`, `price_cents`, `price_type
 </CodeGroup>
 
 <Tip>
-  Pair with `goody_products_get` for richer detail before committing, or
-  `goody_gift_of_choice_list` when the recipient's taste is unknown — let them pick.
+  Pair with [`goody_products_get`](/mcp-reference/tools/products-get) for richer detail before committing, or
+  [`goody_gift_of_choice_list`](/mcp-reference/tools/gift-of-choice-list) when the recipient's taste is unknown — let them pick.
 </Tip>

--- a/mcp-reference/tools/workspaces-list.mdx
+++ b/mcp-reference/tools/workspaces-list.mdx
@@ -1,0 +1,51 @@
+---
+title: "goody_workspaces_list"
+sidebarTitle: "workspaces_list"
+description: "Lists the Goody workspaces the connected user can gift from."
+---
+
+**Permission:** `Read` · **Workspace:** not required (global)
+
+Lists the Goody workspaces the connected user belongs to. Call before any tool that creates, updates, or sends gifts — they all require an explicit `workspace_id`, and this is the only way to discover valid ones.
+
+## Parameters
+
+This tool takes no arguments.
+
+## Returns
+
+<ResponseField name="workspaces" type="object[]">
+  The workspaces the connected user belongs to.
+  <Expandable title="workspace">
+    <ResponseField name="id" type="string">Workspace UUID — pass as `workspace_id` to any tool that requires one.</ResponseField>
+    <ResponseField name="name" type="string">Workspace name.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example
+
+<CodeGroup>
+```text 💬 Prompt
+"What workspaces can I send gifts from?"
+```
+
+```json 🔧 Tool call
+{
+  "name": "goody_workspaces_list",
+  "arguments": {}
+}
+```
+
+```json ↩️ Result
+{
+  "workspaces": [
+    { "id": "0f3c…", "name": "Northwind Trading" },
+    { "id": "9a17…", "name": "Northwind Labs" }
+  ]
+}
+```
+</CodeGroup>
+
+<Tip>
+  Start a session with [`goody_me_get`](/mcp-reference/tools/me-get) to confirm the account, then pass a `workspace_id` from here to tools like [`goody_collections_list`](/mcp-reference/tools/collections-list) or [`goody_order_batches_create`](/mcp-reference/tools/order-batches-create).
+</Tip>

--- a/mcp/authentication.mdx
+++ b/mcp/authentication.mdx
@@ -21,9 +21,13 @@ When you authorize, Goody requests three permissions:
 | **Send gifts** | Send gifts and set up recurring autogifts using your saved payment methods. **This is the only permission that can spend money — and it always works with your confirmation:** the assistant must show the estimated total and get your explicit "yes" before any gift is sent. |
 
 <Warning>
-  Pricing a gift never charges anything — it's a free estimate. Only the **Send
+  Pricing and previewing a gift never charge anything — they're free. Only the **Send
   gifts** actions move money, and only after you confirm.
 </Warning>
+
+## Spending limits
+
+Beyond per-gift confirmation, gifts sent through AI connectors are held under a **rolling daily spend limit** for your account. You can review and adjust it — including raising it, lowering it, or setting it to zero to block AI-initiated spend entirely — in **Goody for Business → account settings → [Connect AI tools](#disconnecting)**. The limit applies across every AI tool you connect, not per tool.
 
 ## Disconnecting
 

--- a/mcp/authentication.mdx
+++ b/mcp/authentication.mdx
@@ -8,7 +8,7 @@ The Goody MCP server authenticates with **OAuth** — authorization code flow wi
 
 ## Signing in
 
-When you connect, your client redirects you to Goody to sign in (or create a Goody for Business account). You then review and approve the permissions the connector requests. You can revoke that approval at any time — see [Disconnecting](#disconnecting).
+When you connect, your client redirects you to Goody to sign in (or create a Goody for Business account). You then review and approve the permissions the Goody MCP server requests. You can revoke that approval at any time — see [Disconnecting](#disconnecting).
 
 ## Permissions
 
@@ -17,7 +17,7 @@ When you authorize, Goody requests three permissions:
 | Permission | What it lets the assistant do |
 |---|---|
 | **Read** | See your account basics — profile, workspaces, contacts, contact lists, past gifts and orders, and saved payment methods (display names only, never card numbers) — and browse Goody's gift catalog and greeting cards. |
-| **Write** | Create and edit things that don't cost money: add or update contacts, create contact lists, and calculate the price of a gift before anything is sent. |
+| **Write** | Create and edit things that don't cost money: add or update contacts, create contact lists, and price a gift before anything is sent. Pricing needs Write because it builds a draft order to estimate the total — it's a create-style preview, not a charge (see the note below). |
 | **Send gifts** | Send gifts and set up recurring autogifts using your saved payment methods. **This is the only permission that can spend money — and it always works with your confirmation:** the assistant must show the estimated total and get your explicit "yes" before any gift is sent. |
 
 <Warning>

--- a/mcp/authentication.mdx
+++ b/mcp/authentication.mdx
@@ -1,39 +1,58 @@
 ---
 title: "Authentication & permissions"
 sidebarTitle: "Authentication"
-description: "How OAuth sign-in works for the Goody MCP server, and what the Read, Write, and Send gifts permissions allow."
+description: "How the Goody MCP server authenticates — OAuth for interactive clients, personal tokens for scripts and automations — and what the Read, Write, and Send gifts permissions allow."
 ---
 
-The Goody MCP server authenticates with **OAuth** — authorization code flow with PKCE, refresh tokens, and Dynamic Client Registration. You don't configure any of this by hand: your MCP client discovers the endpoints automatically and walks you through Goody's sign-in screen.
+The Goody MCP server supports two ways to authenticate, both built on the same permissions and safeguards. Interactive AI clients use **OAuth**; scripts and automations use a **personal MCP token**. Either way, what a connection can do is governed by the three permissions below — and **Send gifts** is the only one that can spend money.
 
-## Signing in
+## Two ways to connect
 
-When you connect, your client redirects you to Goody to sign in (or create a Goody for Business account). You then review and approve the permissions the Goody MCP server requests. You can revoke that approval at any time — see [Disconnecting](#disconnecting).
+<Tabs>
+  <Tab title="OAuth (interactive clients)">
+    Claude (web, desktop, mobile), Cursor, ChatGPT's MCP support, and other interactive AI clients connect through **OAuth** — authorization code flow with PKCE, refresh tokens, and Dynamic Client Registration. You add Goody as a connector, sign in once in the browser, and approve the permissions; the client then stores and silently refreshes short-lived tokens. There's nothing to paste into a config file.
+
+    This is the [Connect](/mcp/connect) path — use it for any client a person drives in a chat. Manage these connections in **Goody for Business → account settings → Connect AI tools**.
+  </Tab>
+  <Tab title="Personal MCP token (scripts & automations)">
+    For scripts, n8n / Zapier / Make workflows, cron jobs, or headless agent frameworks — anywhere a browser sign-in isn't an option — mint a **personal MCP token** in **Goody for Business → account settings → Personal MCP token**, and paste it together with the [server URL](/mcp/connect) into your client's config.
+
+    When you create a token you choose:
+
+    - a **name** (e.g. "Zapier — Marketing") so you can identify and revoke it later,
+    - its **scopes** — any of `mcp.read`, `mcp.write`, `mcp.gifts` (see [Permissions](#permissions)), and
+    - an **expiry** — 30 days, 90 days (recommended), 1 year, or no expiry.
+
+    The full token is shown **once**, at creation — store it somewhere safe. You can hold several active tokens and revoke any of them at any time.
+  </Tab>
+</Tabs>
+
+It's the same server, the same scopes, and the same enforcement either way — the only difference is how the credential is obtained.
 
 ## Permissions
 
-When you authorize, Goody requests three permissions:
+Whether granted via OAuth consent or selected as a token's scopes, a connection carries one or more of three permissions:
 
-| Permission | What it lets the assistant do |
-|---|---|
-| **Read** | See your account basics — profile, workspaces, contacts, contact lists, past gifts and orders, and saved payment methods (display names only, never card numbers) — and browse Goody's gift catalog and greeting cards. |
-| **Write** | Create and edit things that don't cost money: add or update contacts, create contact lists, and price a gift before anything is sent. Pricing needs Write because it builds a draft order to estimate the total — it's a create-style preview, not a charge (see the note below). |
-| **Send gifts** | Send gifts and set up recurring autogifts using your saved payment methods. **This is the only permission that can spend money — and it always works with your confirmation:** the assistant must show the estimated total and get your explicit "yes" before any gift is sent. |
+| Permission | Scope | What it allows |
+|---|---|---|
+| **Read** | `mcp.read` | See your account basics — profile, workspaces, contacts, contact lists, past gifts and orders, and saved payment methods (display names only, never card numbers) — and browse Goody's gift catalog and greeting cards. |
+| **Write** | `mcp.write` | Create and edit things that don't cost money: add or update contacts, create contact lists, cancel an unaccepted order, and price or preview a gift before sending. Preview/price need Write because they build a draft order to estimate the total — a create-style preview, not a charge. |
+| **Send gifts** | `mcp.gifts` | Send gifts and activate recurring autogifts using your payment methods. **This is the only permission that can spend money.** With an interactive client a person still confirms each send; with an unattended token, this is the permission that lets an automation spend on your behalf — see [Automatic & agentic sends](/mcp/gifting-flow#automatic--agentic-sends). |
 
 <Warning>
   Pricing and previewing a gift never charge anything — they're free. Only the **Send
-  gifts** actions move money, and only after you confirm.
+  gifts** permission moves money. Grant it only to connections or tokens you intend to let spend.
 </Warning>
 
 ## Spending limits
 
-Beyond per-gift confirmation, gifts sent through AI connectors are held under a **rolling daily spend limit** for your account. You can review and adjust it — including raising it, lowering it, or setting it to zero to block AI-initiated spend entirely — in **Goody for Business → account settings → [Connect AI tools](#disconnecting)**. The limit applies across every AI tool you connect, not per tool.
+Beyond per-gift confirmation, gifts sent through AI connectors are held under a **rolling daily spend limit** for your account. You can review and adjust it — including raising it, lowering it, or setting it to zero to block AI-initiated spend entirely — in **Goody for Business → account settings → [Connect AI tools](#disconnecting)**. The limit applies across every AI tool and token you connect, not per connection — so it backstops unattended automations as well as interactive sessions.
 
 ## Disconnecting
 
-You're in control of the connection from either side:
+You're in control of every connection from either side:
 
-- **From Goody:** open **Goody for Business → account settings → Connect AI tools**. You'll see every connected AI tool, when it connected, and its permissions — click **Disconnect** to revoke it instantly.
-- **From Claude:** remove or disable the Goody connector in **Settings → Connectors**.
+- **From Goody:** open **Goody for Business → account settings**. **Connect AI tools** lists every OAuth-connected AI tool — when it connected and its permissions — with **Disconnect** to revoke it instantly. **Personal MCP token** lists your active tokens, each with **Revoke**.
+- **From the client:** remove or disable the Goody connector in the client's settings (in Claude: **Settings → Connectors**), or delete the token from your script's config.
 
-A disconnected tool must be re-authorized by you before it can access your account again.
+A disconnected tool or revoked token must be re-authorized — or a new token minted — before it can access your account again.

--- a/mcp/authentication.mdx
+++ b/mcp/authentication.mdx
@@ -1,0 +1,35 @@
+---
+title: "Authentication & permissions"
+sidebarTitle: "Authentication"
+description: "How OAuth sign-in works for the Goody MCP server, and what the Read, Write, and Send gifts permissions allow."
+---
+
+The Goody MCP server authenticates with **OAuth** — authorization code flow with PKCE, refresh tokens, and Dynamic Client Registration. You don't configure any of this by hand: your MCP client discovers the endpoints automatically and walks you through Goody's sign-in screen.
+
+## Signing in
+
+When you connect, your client redirects you to Goody to sign in (or create a Goody for Business account). You then review and approve the permissions the connector requests. You can revoke that approval at any time — see [Disconnecting](#disconnecting).
+
+## Permissions
+
+When you authorize, Goody requests three permissions:
+
+| Permission | What it lets the assistant do |
+|---|---|
+| **Read** | See your account basics — profile, workspaces, contacts, contact lists, past gifts and orders, and saved payment methods (display names only, never card numbers) — and browse Goody's gift catalog and greeting cards. |
+| **Write** | Create and edit things that don't cost money: add or update contacts, create contact lists, and calculate the price of a gift before anything is sent. |
+| **Send gifts** | Send gifts and set up recurring autogifts using your saved payment methods. **This is the only permission that can spend money — and it always works with your confirmation:** the assistant must show the estimated total and get your explicit "yes" before any gift is sent. |
+
+<Warning>
+  Pricing a gift never charges anything — it's a free estimate. Only the **Send
+  gifts** actions move money, and only after you confirm.
+</Warning>
+
+## Disconnecting
+
+You're in control of the connection from either side:
+
+- **From Goody:** open **Goody for Business → account settings → Connect AI tools**. You'll see every connected AI tool, when it connected, and its permissions — click **Disconnect** to revoke it instantly.
+- **From Claude:** remove or disable the Goody connector in **Settings → Connectors**.
+
+A disconnected tool must be re-authorized by you before it can access your account again.

--- a/mcp/connect.mdx
+++ b/mcp/connect.mdx
@@ -23,13 +23,13 @@ You can connect Goody to Claude — or any MCP-compatible client — in two ways
   </Step>
 </Steps>
 
-## As a custom connector
+## In any MCP client (custom connector)
 
-If you don't see Goody listed yet, add it by URL. This works in Claude and any other MCP client.
+Any MCP client that supports remote OAuth servers can add Goody by URL — Claude (web, desktop, and mobile) and others. Point the client at the server URL and complete OAuth sign-in. In Claude specifically, use the steps below; in another client, add a custom/remote MCP server with the same URL.
 
 <Steps>
   <Step title="Add a custom connector">
-    In claude.ai, go to **Settings → Connectors → Add custom connector**.
+    In claude.ai, go to **Settings → Connectors → Add custom connector**. In another MCP client, open its custom or remote MCP server settings.
   </Step>
   <Step title="Enter the server URL">
     ```text
@@ -42,8 +42,15 @@ If you don't see Goody listed yet, add it by URL. This works in Claude and any o
 </Steps>
 
 <Note>
-  A Goody for Business account is required. The connector acts only within the
-  Goody workspaces you're a member of, and gifts you send appear in your Goody
+  The Goody MCP server publishes the standard OAuth authorization-server and
+  protected-resource metadata, so any compliant client discovers the
+  authorization, token, and registration endpoints from the URL alone — there's
+  nothing to configure by hand.
+</Note>
+
+<Note>
+  A Goody for Business account is required. The Goody MCP server acts only within
+  the Goody workspaces you're a member of, and gifts you send appear in your Goody
   dashboard exactly like gifts sent from the website.
 </Note>
 

--- a/mcp/connect.mdx
+++ b/mcp/connect.mdx
@@ -1,0 +1,52 @@
+---
+title: "Connect Goody to Claude"
+sidebarTitle: "Connect"
+description: "Add the Goody connector in Claude from the connectors directory, or as a custom connector using the server URL."
+---
+
+You can connect Goody to Claude — or any MCP-compatible client — in two ways.
+
+## From the connectors directory
+
+<Steps>
+  <Step title="Open Connectors settings">
+    In claude.ai, go to **Settings → Connectors**.
+  </Step>
+  <Step title="Find Goody and connect">
+    Search for **Goody** in the directory and click **Connect**.
+  </Step>
+  <Step title="Sign in to Goody">
+    You'll be redirected to Goody to sign in — or to create a Goody for Business account if you don't have one.
+  </Step>
+  <Step title="Authorize">
+    Review the permissions Goody requests and click **Authorize**. Goody now appears as a connected tool — start a new chat and try an [example prompt](/mcp-reference/example-prompts).
+  </Step>
+</Steps>
+
+## As a custom connector
+
+If you don't see Goody listed yet, add it by URL. This works in Claude and any other MCP client.
+
+<Steps>
+  <Step title="Add a custom connector">
+    In claude.ai, go to **Settings → Connectors → Add custom connector**.
+  </Step>
+  <Step title="Enter the server URL">
+    ```text
+    https://api.ongoody.com/mcp/v1
+    ```
+  </Step>
+  <Step title="Sign in and authorize">
+    Complete the same Goody sign-in and authorization steps as above.
+  </Step>
+</Steps>
+
+<Note>
+  A Goody for Business account is required. The connector acts only within the
+  Goody workspaces you're a member of, and gifts you send appear in your Goody
+  dashboard exactly like gifts sent from the website.
+</Note>
+
+## Supported clients
+
+Any MCP client that supports remote servers with OAuth works, including Claude on web, desktop, and mobile. The server uses the standard Streamable HTTP transport, so no local proxy or command-line setup is required.

--- a/mcp/connect.mdx
+++ b/mcp/connect.mdx
@@ -54,13 +54,39 @@ For scripts, n8n / Zapier / Make workflows, cron jobs, or headless agent framewo
     In Goody for Business, go to **account settings → Personal MCP token**. Give it a name, choose its [scopes](/mcp/authentication#permissions) (Read / Write / Send gifts), and pick an expiry. The token is shown **once** — copy it now.
   </Step>
   <Step title="Configure your client">
-    Point your MCP client at the same server URL and pass the token as a bearer credential:
+    Point your MCP client at the server URL and pass the token in an `Authorization: Bearer` header. Both are required.
 
-    ```text
-    https://api.ongoody.com/mcp/v1
+    <CodeGroup>
+    ```json Streamable HTTP client
+    {
+      "mcpServers": {
+        "goody": {
+          "url": "https://api.ongoody.com/mcp/v1",
+          "headers": {
+            "Authorization": "Bearer YOUR_PERSONAL_MCP_TOKEN"
+          }
+        }
+      }
+    }
     ```
 
-    Both the URL and the token are required.
+    ```json Via mcp-remote (stdio-only clients)
+    {
+      "mcpServers": {
+        "goody": {
+          "command": "npx",
+          "args": [
+            "-y", "mcp-remote",
+            "https://api.ongoody.com/mcp/v1",
+            "--header", "Authorization: Bearer YOUR_PERSONAL_MCP_TOKEN"
+          ]
+        }
+      }
+    }
+    ```
+    </CodeGroup>
+
+    Use the direct Streamable HTTP form when your client supports remote MCP servers with custom headers. Use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge for clients that only speak stdio.
   </Step>
 </Steps>
 

--- a/mcp/connect.mdx
+++ b/mcp/connect.mdx
@@ -45,6 +45,31 @@ Any MCP client that supports remote OAuth servers can add Goody by URL — Claud
   dashboard exactly like gifts sent from the website.
 </Note>
 
+## Connect a script or automation
+
+For scripts, n8n / Zapier / Make workflows, cron jobs, or headless agent frameworks — anywhere a browser-based OAuth sign-in isn't an option — connect with a **personal MCP token** instead.
+
+<Steps>
+  <Step title="Create a personal MCP token">
+    In Goody for Business, go to **account settings → Personal MCP token**. Give it a name, choose its [scopes](/mcp/authentication#permissions) (Read / Write / Send gifts), and pick an expiry. The token is shown **once** — copy it now.
+  </Step>
+  <Step title="Configure your client">
+    Point your MCP client at the same server URL and pass the token as a bearer credential:
+
+    ```text
+    https://api.ongoody.com/mcp/v1
+    ```
+
+    Both the URL and the token are required.
+  </Step>
+</Steps>
+
+<Warning>
+  A personal MCP token is a credential — anyone with it can act with the scopes you granted, including spending money if you selected **Send gifts**. Store it like a password, scope it to only what the automation needs, and revoke it from the same page if it's exposed.
+</Warning>
+
+See [Authentication & permissions](/mcp/authentication) for how the two methods compare and what each permission allows.
+
 ## Supported clients
 
-Any MCP client that supports remote servers with OAuth works, including Claude on web, desktop, and mobile. The server uses the standard Streamable HTTP transport, so no local proxy or command-line setup is required.
+Any MCP client that supports remote servers works. **Interactive clients** (Claude on web, desktop, and mobile; Cursor; ChatGPT's MCP support) connect over OAuth with no setup beyond the server URL. **Scripts and automations** connect with a personal MCP token. The server uses the standard Streamable HTTP transport, so no local proxy or command-line setup is required.

--- a/mcp/connect.mdx
+++ b/mcp/connect.mdx
@@ -1,29 +1,17 @@
 ---
 title: "Connect Goody to Claude"
 sidebarTitle: "Connect"
-description: "Add the Goody connector in Claude from the connectors directory, or as a custom connector using the server URL."
+description: "Add Goody to Claude as a custom connector using the server URL. (Directory listing is rolling out.)"
 ---
 
-You can connect Goody to Claude — or any MCP-compatible client — in two ways.
+You can connect Goody to Claude — or any MCP-compatible client — by adding it as a custom connector with the server URL.
 
-## From the connectors directory
+<Note>
+  The Claude Connectors Directory listing is rolling out — for now, add Goody as a
+  custom connector below.
+</Note>
 
-<Steps>
-  <Step title="Open Connectors settings">
-    In claude.ai, go to **Settings → Connectors**.
-  </Step>
-  <Step title="Find Goody and connect">
-    Search for **Goody** in the directory and click **Connect**.
-  </Step>
-  <Step title="Sign in to Goody">
-    You'll be redirected to Goody to sign in — or to create a Goody for Business account if you don't have one.
-  </Step>
-  <Step title="Authorize">
-    Review the permissions Goody requests and click **Authorize**. Goody now appears as a connected tool — start a new chat and try an [example prompt](/mcp-reference/example-prompts).
-  </Step>
-</Steps>
-
-## In any MCP client (custom connector)
+## Add Goody as a custom connector
 
 Any MCP client that supports remote OAuth servers can add Goody by URL — Claude (web, desktop, and mobile) and others. Point the client at the server URL and complete OAuth sign-in. In Claude specifically, use the steps below; in another client, add a custom/remote MCP server with the same URL.
 
@@ -36,8 +24,11 @@ Any MCP client that supports remote OAuth servers can add Goody by URL — Claud
     https://api.ongoody.com/mcp/v1
     ```
   </Step>
-  <Step title="Sign in and authorize">
-    Complete the same Goody sign-in and authorization steps as above.
+  <Step title="Sign in to Goody">
+    You'll be redirected to Goody to sign in — or to create a Goody for Business account if you don't have one.
+  </Step>
+  <Step title="Authorize">
+    Review the permissions Goody requests and click **Authorize**. Goody now appears as a connected tool — start a new chat and try an [example prompt](/mcp-reference/example-prompts).
   </Step>
 </Steps>
 

--- a/mcp/data-handling.mdx
+++ b/mcp/data-handling.mdx
@@ -1,0 +1,33 @@
+---
+title: "Data handling & support"
+sidebarTitle: "Data handling"
+description: "What Goody records about MCP usage, what it never stores, and how to reach support."
+---
+
+The Goody MCP server is deliberately thin on what it keeps. It records enough to operate the service and understand usage — and nothing about the content of your conversation.
+
+## What Goody records
+
+For each tool call, Goody stores a single usage record containing:
+
+- the **tool name** (e.g. `goody_products_search`),
+- the **permission** it ran under (Read / Write / Send gifts),
+- the **outcome** — success or error, and the error type if it failed,
+- how **long** it took, and
+- for money-spending tools, a few **non-identifying numbers** — such as an estimated amount and the resulting gift-batch reference — used to track spend.
+
+This is operational telemetry: it powers metrics, debugging, and the spend safeguards.
+
+## What Goody never stores
+
+- Your **conversation** or prompts.
+- The **arguments** you pass to tools — recipient names, emails, phone numbers, mailing addresses, or card-message text.
+- Any **free-text** content. The usage record is restricted to small, non-identifying values by design, so personal data can't leak into it.
+
+Gifts you actually send are, of course, recorded in your Goody account — the same way a gift sent from the website is — so they appear in your dashboard, receipts, and order history. That's your account data, not MCP telemetry.
+
+For full details on how Goody handles personal data, see the [Goody Privacy Policy](https://www.ongoody.com/legal/privacy-policy).
+
+## Support
+
+Questions, issues, or feedback about the Goody MCP server? Email [support@ongoody.com](mailto:support@ongoody.com). You can also send feedback to the Goody team directly from a conversation — just ask the assistant to pass it along.

--- a/mcp/gifting-flow.mdx
+++ b/mcp/gifting-flow.mdx
@@ -13,31 +13,53 @@ A send moves through a few clear steps. The assistant orchestrates them for you 
   <Step title="Compose">
     Pick a greeting card and an optional card message (the assistant can draft a few), choose the recipient, and select a payment method.
   </Step>
-  <Step title="Price">
-    The assistant prices the gift — subtotal, shipping, and estimated tax — and relays the total to you. Pricing is free and can be run as many times as you like.
+  <Step title="Preview">
+    The assistant builds a **preview link** — a real page showing the assembled gift (card, message, products) — and prices it in full: subtotal, shipping, and estimated tax. Nothing is charged. This is the step you confirm against: you see exactly what the recipient will get, and the total, before anything happens.
   </Step>
   <Step title="Confirm & send">
-    Only after you say yes does the assistant send the gift. It returns a preview link showing exactly what the recipient will see.
+    Only after you say yes does the assistant send the gift. It returns the same preview link plus a one-line summary of whether and how the recipient was notified.
   </Step>
 </Steps>
 
-## No address needed
+<Note>
+  Need just a number? The assistant can run a quick **price estimate** at any time without building a preview. The preview is the richer, confirm-against-it step — it returns the link, the price, the From name, the payment method, and how recipients are notified, all in one.
+</Note>
 
-Recipients don't need to share an address with you. They receive a gift link (by email, or a link you share), enter their own shipping details when they accept, and can swap the gift for something else — unless you ask to disable swapping.
+## How recipients receive a gift
+
+You choose one of three send methods, and the assistant tells you which it's using — because each reaches the recipient differently:
+
+- **Gift link you share** — the recipient is *not* automatically notified; you get a link to send them yourself.
+- **Email** — Goody emails each recipient a notification with their gift link.
+- **Direct shipping** — Goody ships the physical product straight to a mailing address you provide (no email). US addresses today.
+
+For the link and email methods, recipients don't need to share an address up front: they enter their own shipping details when they accept, and can swap the gift for something else — unless you disable swapping.
 
 ## How spending is protected
 
-Nothing is charged without you seeing the price and confirming. This is enforced in two layers:
+Nothing is charged without you seeing the price and confirming. This is enforced in a few layers:
 
 - **In the Goody MCP server.** The send action cannot run until a price has been presented and you've confirmed it. Recurring autogifts are always created **paused** — they can't spend anything until you explicitly activate them.
 - **In the client.** The money-spending actions are flagged as sensitive, so Claude asks your permission before running them rather than acting silently.
+- **A daily spend cap.** Gifts sent through AI connectors are held under a rolling daily spend limit, which you can review and adjust (including turning it off, or down to zero) in **Goody for Business → account settings → Connect AI tools**.
 
 Other defaults worth knowing:
 
 - **US shipping is the default.** If your recipient is outside the US, say so — the assistant searches international-friendly gifts and enables global delivery.
-- **Alcohol is excluded by default** unless you explicitly ask for it (alcohol gifts require age attestation and a card payment).
+- **Alcohol is excluded by default** unless you explicitly ask for it (alcohol gifts require age attestation and a card payment, and can't be paid from Balance).
 - **Sending doesn't auto-save recipients** as contacts — the assistant offers to, and only saves if you agree.
+
+## Scheduling, expiration, and payment
+
+- **Schedule for later.** Ask to send on a future date and the assistant schedules it — any time in the next 3 months.
+- **Expiration.** A gift link can expire if the recipient hasn't accepted it. The assistant asks rather than guessing; Goody's standard window is about 10 weeks. (An expiration date is required when you pay from your Goody Balance.)
+- **Payment source.** Pay with a saved card, your **Goody Balance**, or a **Corporate Account**. The assistant shows you which funding source it will charge before you confirm.
 
 ## Recurring gifts (autogifts)
 
-An autogift is a rule: "every year on this person's birthday or work anniversary, send this gift." You create one by reusing a gift you've already sent — same gift, card, message, and payment method. Autogifts are always **created paused**, and activating one re-checks that the gift is still available and the payment method still works. Supported triggers today: **birthday**, **work anniversary**, and **employee onboarding**.
+An autogift is a rule: "every year on this person's birthday or work anniversary, send this gift." You can create one two ways:
+
+- **Clone a past send** — reuse a gift you've already sent (same gift, card, message, and payment method).
+- **Build from scratch** — no prior send required: pick a product, card, message, and payment method, and the assistant assembles the rule directly.
+
+Autogifts are always **created paused**. Before activating, ask the assistant to **preview** the rule — it shows the card, message, product, and the expected per-send cost. Activating one re-checks that the gift is still available and the payment method still works. Supported triggers today: **birthday**, **work anniversary**, and **employee onboarding**.

--- a/mcp/gifting-flow.mdx
+++ b/mcp/gifting-flow.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The gifting flow"
 sidebarTitle: "Gifting flow"
-description: "How a gift goes from idea to sent through the Goody connector, and how the spend-confirmation safeguards work."
+description: "How a gift goes from idea to sent through the Goody MCP server, and how the spend-confirmation safeguards work."
 ---
 
 A send moves through a few clear steps. The assistant orchestrates them for you — this is what's happening under the hood.
@@ -29,7 +29,7 @@ Recipients don't need to share an address with you. They receive a gift link (by
 
 Nothing is charged without you seeing the price and confirming. This is enforced in two layers:
 
-- **In the Goody server.** The send action cannot run until a price has been presented and you've confirmed it. Recurring autogifts are always created **paused** — they can't spend anything until you explicitly activate them.
+- **In the Goody MCP server.** The send action cannot run until a price has been presented and you've confirmed it. Recurring autogifts are always created **paused** — they can't spend anything until you explicitly activate them.
 - **In the client.** The money-spending actions are flagged as sensitive, so Claude asks your permission before running them rather than acting silently.
 
 Other defaults worth knowing:

--- a/mcp/gifting-flow.mdx
+++ b/mcp/gifting-flow.mdx
@@ -63,3 +63,24 @@ An autogift is a rule: "every year on this person's birthday or work anniversary
 - **Build from scratch** — no prior send required: pick a product, card, message, and payment method, and the assistant assembles the rule directly.
 
 Autogifts are always **created paused**. Before activating, ask the assistant to **preview** the rule — it shows the card, message, product, and the expected per-send cost. Activating one re-checks that the gift is still available and the payment method still works. Supported triggers today: **birthday**, **work anniversary**, and **employee onboarding**.
+
+## Automatic & agentic sends
+
+Not every send has a human watching. A gift might go out from a scheduled send, a recurring autogift, or a Claude routine running on its own. Confirmation can't happen at the moment of sending then — so approval moves earlier, and the spending limit backstops it.
+
+There are two modes:
+
+- **Human in the loop** — the everyday case. The assistant previews the gift, you confirm the price, and only then does it send. You approve *each* send.
+- **Unattended** — a scheduled send, an autogift, or an autonomous agent or routine (see [how clients authenticate](/mcp/authentication#two-ways-to-connect)). You approve *once, up front*; the gift sends later with no one watching.
+
+For an unattended send, your confirmation is the consent you give before it ever runs, in three layers:
+
+1. **The permission you granted.** The connection must carry the **Send gifts** permission — granted when you authorize an interactive client over OAuth, or selected as a scope when you mint a [personal MCP token](/mcp/authentication#two-ways-to-connect) for a script, cron job, or headless agent. Without it, the agent can preview and price, but never send.
+2. **The automation you set up.** Activating an autogift, scheduling a send, or writing a routine's standing instructions *is* your advance approval of what gets sent and when. For autogifts, **activation** — not creation — is the commit point: rules are created paused and preview their cost first.
+3. **The spending limit.** The rolling daily cap (set in **Connect AI tools**) bounds total spend however a send is triggered, so an automation that misbehaves can't run away.
+
+<Note>
+  **Worked example.** You ask Claude to run a daily routine: *"Every morning, check my calendar; if it's a direct report's birthday, send them a $50 gift of choice with a warm note."* When it fires next Tuesday you aren't there, so there's no per-gift "send it?" prompt. Your confirmation already happened — you granted **Send gifts** when you connected, you wrote the routine's rule, and your daily spend cap limits the exposure if something goes wrong. The agent assembles and sends each gift on its own, within those bounds.
+</Note>
+
+A calendar- or routine-driven send like that is the **agent** acting autonomously — distinct from a Goody **autogift**, which only triggers on a birthday, work anniversary, or onboarding date and is fired by Goody itself. Reach for an autogift when the occasion is one of those three; use a routine or your own agent for anything else.

--- a/mcp/gifting-flow.mdx
+++ b/mcp/gifting-flow.mdx
@@ -1,0 +1,43 @@
+---
+title: "The gifting flow"
+sidebarTitle: "Gifting flow"
+description: "How a gift goes from idea to sent through the Goody connector, and how the spend-confirmation safeguards work."
+---
+
+A send moves through a few clear steps. The assistant orchestrates them for you — this is what's happening under the hood.
+
+<Steps>
+  <Step title="Discover">
+    The assistant searches the catalog by your intent, budget, and occasion (returning up to **5 strong matches**), and can also offer a **Gift of Choice** the recipient picks themselves.
+  </Step>
+  <Step title="Compose">
+    Pick a greeting card and an optional card message (the assistant can draft a few), choose the recipient, and select a payment method.
+  </Step>
+  <Step title="Price">
+    The assistant prices the gift — subtotal, shipping, and estimated tax — and relays the total to you. Pricing is free and can be run as many times as you like.
+  </Step>
+  <Step title="Confirm & send">
+    Only after you say yes does the assistant send the gift. It returns a preview link showing exactly what the recipient will see.
+  </Step>
+</Steps>
+
+## No address needed
+
+Recipients don't need to share an address with you. They receive a gift link (by email, or a link you share), enter their own shipping details when they accept, and can swap the gift for something else — unless you ask to disable swapping.
+
+## How spending is protected
+
+Nothing is charged without you seeing the price and confirming. This is enforced in two layers:
+
+- **In the Goody server.** The send action cannot run until a price has been presented and you've confirmed it. Recurring autogifts are always created **paused** — they can't spend anything until you explicitly activate them.
+- **In the client.** The money-spending actions are flagged as sensitive, so Claude asks your permission before running them rather than acting silently.
+
+Other defaults worth knowing:
+
+- **US shipping is the default.** If your recipient is outside the US, say so — the assistant searches international-friendly gifts and enables global delivery.
+- **Alcohol is excluded by default** unless you explicitly ask for it (alcohol gifts require age attestation and a card payment).
+- **Sending doesn't auto-save recipients** as contacts — the assistant offers to, and only saves if you agree.
+
+## Recurring gifts (autogifts)
+
+An autogift is a rule: "every year on this person's birthday or work anniversary, send this gift." You create one by reusing a gift you've already sent — same gift, card, message, and payment method. Autogifts are always **created paused**, and activating one re-checks that the gift is still available and the payment method still works. Supported triggers today: **birthday**, **work anniversary**, and **employee onboarding**.

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -33,7 +33,7 @@ The two endpoints are independent environments backed by separate Goody for Busi
     Search the catalog by intent, budget, and occasion; browse curated collections and greeting cards; or offer a Gift of Choice the recipient picks themselves.
   </Card>
   <Card title="Send with confirmation" icon="paper-plane">
-    Price a gift, review the total, and send by link or email — only after you confirm.
+    Preview the assembled gift, review the total, and send by link, email, or direct shipping — only after you confirm.
   </Card>
   <Card title="Manage contacts" icon="address-book">
     Find, create, and update workspace contacts and organize them into lists.
@@ -62,4 +62,8 @@ The two endpoints are independent environments backed by separate Goody for Busi
 
 ## Tools
 
-The server exposes **24 tools** across discovery, contacts, sending, and automation. See the [tool reference](/mcp-reference/tools) for the full list and the permission each one requires.
+The server exposes **28 tools** across discovery, contacts, sending, and automation. See the [tool reference](/mcp-reference/tools) for the full list and the permission each one requires.
+
+## Data & support
+
+The Goody MCP server records only non-identifying usage telemetry — never your conversation or tool arguments. See [Data handling](/mcp/data-handling) for specifics and how to reach support.

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -6,7 +6,7 @@ description: "Send and manage business gifts directly from Claude and other MCP 
 
 The **Goody MCP server** brings Goody's business gifting platform into Claude and any other [Model Context Protocol](https://modelcontextprotocol.io) client. Once connected, you can ask the assistant to find the right gift for a budget and occasion, draft the card message, show you the exact price, and send the gift — without ever needing the recipient's mailing address.
 
-It's not just one-off sends. The assistant can also manage the work around the send — look up and save contacts, organize them into lists, review past gifts and orders, and set up recurring "autogifts" for birthdays and work anniversaries. Anything that spends money always works the same way: **you see the full price first, and nothing is charged until you say yes.**
+It's not just one-off sends. The assistant can also manage the work around a send — look up and save contacts, organize them into lists, review past gifts and orders, and set up recurring "autogifts." Anything that spends money always works the same way: **you see the full price first, and nothing is charged until you say yes.**
 
 ## Endpoint
 
@@ -22,6 +22,10 @@ https://api.sandbox.ongoody.com/mcp/v1
 
 The server speaks the standard MCP **Streamable HTTP** transport and authenticates with OAuth — most clients need only the URL above and will walk you through sign-in.
 
+## Sandbox vs production
+
+The two endpoints are independent environments backed by separate Goody for Business accounts. Sign in to production to send real gifts; sign in to sandbox to test sends without being charged. Point your MCP client at the environment you want and authorize with that environment's account — sign-in is per-environment, and credentials and data do not carry over between the two.
+
 ## What you can do
 
 <CardGroup cols={2}>
@@ -35,7 +39,7 @@ The server speaks the standard MCP **Streamable HTTP** transport and authenticat
     Find, create, and update workspace contacts and organize them into lists.
   </Card>
   <Card title="Automate recurring gifts" icon="repeat">
-    Turn a past send into a birthday or work-anniversary autogift — always created paused until you activate it.
+    Turn a past send into a birthday, work-anniversary, or onboarding autogift — always created paused until you activate it.
   </Card>
 </CardGroup>
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -1,0 +1,61 @@
+---
+title: "Goody MCP Server"
+sidebarTitle: "Overview"
+description: "Send and manage business gifts directly from Claude and other MCP clients — discover a gift, write the card, see the price, and send, all in one conversation."
+---
+
+The **Goody MCP server** brings Goody's business gifting platform into Claude and any other [Model Context Protocol](https://modelcontextprotocol.io) client. Once connected, you can ask the assistant to find the right gift for a budget and occasion, draft the card message, show you the exact price, and send the gift — without ever needing the recipient's mailing address.
+
+It's not just one-off sends. The assistant can also manage the work around the send — look up and save contacts, organize them into lists, review past gifts and orders, and set up recurring "autogifts" for birthdays and work anniversaries. Anything that spends money always works the same way: **you see the full price first, and nothing is charged until you say yes.**
+
+## Endpoint
+
+<CodeGroup>
+```text Production
+https://api.ongoody.com/mcp/v1
+```
+
+```text Sandbox
+https://api.sandbox.ongoody.com/mcp/v1
+```
+</CodeGroup>
+
+The server speaks the standard MCP **Streamable HTTP** transport and authenticates with OAuth — most clients need only the URL above and will walk you through sign-in.
+
+## What you can do
+
+<CardGroup cols={2}>
+  <Card title="Discover the right gift" icon="gift">
+    Search the catalog by intent, budget, and occasion; browse curated collections and greeting cards; or offer a Gift of Choice the recipient picks themselves.
+  </Card>
+  <Card title="Send with confirmation" icon="paper-plane">
+    Price a gift, review the total, and send by link or email — only after you confirm.
+  </Card>
+  <Card title="Manage contacts" icon="address-book">
+    Find, create, and update workspace contacts and organize them into lists.
+  </Card>
+  <Card title="Automate recurring gifts" icon="repeat">
+    Turn a past send into a birthday or work-anniversary autogift — always created paused until you activate it.
+  </Card>
+</CardGroup>
+
+## Get started
+
+<CardGroup cols={2}>
+  <Card title="Connect Goody" icon="plug" href="/mcp/connect">
+    Add Goody in Claude from the connectors directory or as a custom connector.
+  </Card>
+  <Card title="Authentication & permissions" icon="lock" href="/mcp/authentication">
+    How OAuth sign-in works and what the Read / Write / Send gifts permissions mean.
+  </Card>
+  <Card title="The gifting flow" icon="route" href="/mcp/gifting-flow">
+    How a gift goes from idea to sent — and how the spend-confirmation safeguards work.
+  </Card>
+  <Card title="Example prompts" icon="comments" href="/mcp-reference/example-prompts">
+    Real prompts that work today, with illustrative responses.
+  </Card>
+</CardGroup>
+
+## Tools
+
+The server exposes **24 tools** across discovery, contacts, sending, and automation. See the [tool reference](/mcp-reference/tools) for the full list and the permission each one requires.

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -20,7 +20,7 @@ https://api.sandbox.ongoody.com/mcp/v1
 ```
 </CodeGroup>
 
-The server speaks the standard MCP **Streamable HTTP** transport and authenticates with OAuth — most clients need only the URL above and will walk you through sign-in.
+The server speaks the standard MCP **Streamable HTTP** transport. Interactive clients (Claude, Cursor, …) authenticate with OAuth — they need only the URL above and walk you through sign-in. Scripts and automations connect with a personal token instead. See [Authentication](/mcp/authentication).
 
 ## Sandbox vs production
 

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -3,6 +3,10 @@ title: "Changelog"
 description: "Updates to the Goody API"
 ---
 
+### June 9, 2026
+
+- **Goody MCP server (beta).** Connect Goody to Claude and other MCP clients to send and manage gifts in conversation — discover gifts, draft a card message, price, and send with your confirmation, plus contacts and recurring autogifts. See the [MCP overview](/mcp/overview).
+
 ### June 3, 2026
 
 - Add [customer\_reference\_id](https://developer.ongoody.com/api-reference/order-batches/create-an-order-batch#body-customer-reference-id-one-of-0) to OrderBatch, a unique/idempotent ID where you can store an ID reference to your own system.

--- a/resources/changelog.mdx
+++ b/resources/changelog.mdx
@@ -3,9 +3,9 @@ title: "Changelog"
 description: "Updates to the Goody API"
 ---
 
-### June 9, 2026
+### June 25, 2026
 
-- **Goody MCP server (beta).** Connect Goody to Claude and other MCP clients to send and manage gifts in conversation — discover gifts, draft a card message, price, and send with your confirmation, plus contacts and recurring autogifts. See the [MCP overview](/mcp/overview).
+- **Goody MCP server (beta).** Connect Goody to Claude and other MCP clients to send and manage gifts in conversation — discover gifts, draft a card message, preview and price a gift, and send with your confirmation, plus contacts and recurring autogifts. See the [MCP overview](/mcp/overview).
 
 ### June 3, 2026
 


### PR DESCRIPTION
## What

Adds a **Goody MCP server** section to the docs and reframes the Documentation landing so it covers both integration paths (API + MCP).

### Documentation → MCP (guide)
Onboarding pages: **Overview**, **Connect**, **Authentication**, **Gifting flow**.

### MCP Reference (deep reference zone)
- **Capabilities & roadmap** — what's possible today, a **can/can't matrix** (gift cards, collections, autogifts, global shipping, Calendly, Swag, Gmail, cross-account, account credit, …), and a Linear-sourced roadmap.
- **Example prompts** — real flows with illustrative responses.
- **Tools** — an all-tools index, and the first by-resource tool page, `products_search`, in a **💬 prompt → 🔧 tool call → ↩️ result** showcase format.

### Also
- Documentation landing now presents two paths (**API** and **MCP**).
- Added a **Goody MCP server (beta)** entry to the global changelog.

## Status — initial cut for team review

This is a first version to share for feedback. Still being finalized:
- The **tool-showcase format** (see `products_search`) — once approved, the other 23 tools get pages grouped by resource.
- The **can/can't matrix** answers (a few flagged for confirmation: Smart Links, Gmail framing, whether to publicly document the account-credit gap).
- Changelog date for the MCP entry.

Content is grounded in the live tool surface (`app/lib/mcp/external/`) and the Goody MCP Platform Linear project. Validated locally with `mint broken-links` (clean for all new pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
